### PR TITLE
Add redirect page

### DIFF
--- a/src/pages/docs.js
+++ b/src/pages/docs.js
@@ -1,0 +1,11 @@
+// Redirects /docs route to /docs/introduction
+import React from 'react';
+import { Redirect } from '@docusaurus/router';
+
+const Home = () => {
+  return <Redirect to="/docs/introduction" />;
+};
+
+<Redirect to="/docs/introduction" />;
+
+export default Home;


### PR DESCRIPTION
## Changes in this pull request

Redirect `/docs` route to `/docs/introduction`.

Currently https://opensource.contentauthenticity.org/docs/ is 404.  Just redirect that route to https://opensource.contentauthenticity.org/docs/introduction/ which is actually the docs home page...unfortunately.