### PR TITLE
Remove CSS causing outline around tables

### DIFF
--- a/docs/manifest/cai-addon.css
+++ b/docs/manifest/cai-addon.css
@@ -1,43 +1,48 @@
 /* Added by Rand - moved from custom-cai.css */
 div.highlighter-rouge {
-	background-color: #f6f8fa; 
+  background-color: #f6f8fa;
   padding: 5px 10px;
 }
 
-.comment { font-style: italic;}
+.comment {
+  font-style: italic;
+  margin: 0;
+}
 
-.manifest-object { 
-  display: inline-block; 
-  background-color: #e6f2ff; 
-  padding: 5px; 
-  border: 1px solid #024384; 
-  width: fit-content; 
-  border-radius: 10px; 
+.manifest-object {
+  display: inline-block;
+  background-color: #e6f2ff;
+  padding: 5px;
+  border: 1px solid #024384;
+  width: fit-content;
+  border-radius: 10px;
   font-size: 90%;
 }
 
-/* Table styling */
+/* Table styling 
 
 table.manifest-ref-table {
 	border: 1px solid #E1E1E1;
 	margin: 0 0 20px 0;
 	border-collapse: collapse;
 }
+*/
 
-th.manifest-ref-table, td.manifest-ref-table {
-	border: 1px solid #ccc;
-	padding: 10px;
-	font-size: .9em;
-	text-align: left;
+th.manifest-ref-table,
+td.manifest-ref-table {
+  border: 1px solid #ccc;
+  padding: 10px;
+  font-size: 0.9em;
+  text-align: left;
 }
 
 th.manifest-ref-table {
-	background: #e6e6e6;
+  background: #e6e6e6;
 }
 
 .top-scroll-btn {
-	float: right;
-	margin-right: 50px;
+  float: right;
+  margin-right: 50px;
   border: 1px solid #ddd;
   background-color: #ccc; /* Set a background color */
   color: black; /* Text color */
@@ -49,5 +54,5 @@ th.manifest-ref-table {
 
 .top-scroll-btn:hover {
   background-color: #555; /* Add a dark-grey background on hover */
-	color: white;
+  color: white;
 }


### PR DESCRIPTION
Some tables have an extra border around them:

<img width="901" alt="Screenshot 2023-11-29 at 5 23 39 PM" src="https://github.com/contentauth/opensource.contentauth.org/assets/2925364/003f7408-0431-499e-bec6-97f18948fd28">

I thought we fixed this, but this should do it.