### PR TITLE
Make nomenclature consistent with rest of docs

### DIFF
--- a/docs/js-sdk/getting-started/overview.mdx
+++ b/docs/js-sdk/getting-started/overview.mdx
@@ -1,13 +1,13 @@
 ---
 id: overview
-title: JavaScript SDK
+title: JavaScript library
 ---
 
-The CAI JavaScript SDK enables client JavaScript applications to view and verify [C2PA](https://c2pa.org/) data. It performs only **read** operations on C2PA manifests, unlike the [Rust SDK](https://opensource.contentauthenticity.org/docs/rust-sdk/), which can both read and write manifests.
+The CAI JavaScript library (sometimes referred to as the "JavaScript SDK") enables client JavaScript applications to view and verify [C2PA](https://c2pa.org/) data. It performs only **read** operations on C2PA manifests, unlike the [Rust library](https://opensource.contentauthenticity.org/docs/rust-sdk/), which can both read and write manifests.
 
 ## Overview
 
-The JavaScript SDK is a monorepo containing the following packages intended for client use:
+The JavaScript library is a monorepo containing the following packages intended for client use:
 
 - [**c2pa**](https://opensource.contentauthenticity.org/docs/js-sdk/api/c2pa) is the main package used for loading and verifying manifests. This package runs all of the processing
   logic on the client using a [WebAssembly](https://webassembly.org/) module and exposes a [TypeScript](https://www.typescriptlang.org/)-compatible API for easy integration.
@@ -16,28 +16,28 @@ The JavaScript SDK is a monorepo containing the following packages intended for 
 
 To learn how to use these libraries, see the [Quick start](quick-start).
 
-Additionally, the SDK includes the following supporting packages that are _not_ intended for separate use:
+Additionally, the library includes the following supporting packages that are _not_ intended for separate use:
 
 - **@cai/toolkit** contains the WebAssembly module, data binding functions, and related build tools. The `c2pa` package consumes this library under the hood. The WebAssembly module handles manifest parsing and validation.
 - **@cai/detector** provides a high-performance binary scanner to quickly detect if C2PA manifest data exists in a file. The `c2pa` package also consumes this library.
 
 ## Features
 
-Key features of the JavaScript SDK include:
+Key features of the JavaScript library include:
 
 - **Developer friendly**: Full TypeScript support and robust debugging support using the [debug](https://github.com/debug-js/debug) library make integration easy.
-- **Performance**: The processing code of the SDK uses a high-performance [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) binary. Additionally, the library offloads processing tasks to a configurable Web Worker pool to enable parallelization and avoid blocking a web application's main thread.
+- **Performance**: The processing code of the library uses a high-performance [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) binary. Additionally, the library offloads processing tasks to a configurable Web Worker pool to enable parallelization and avoid blocking a web application's main thread.
 - **Lazy loading and processing**: Since images can be quite large, the library inspects the start of an asset file for C2PA manifest data before requesting the entire file, [if the server supports it](../guides/hosting#range-requests). The library will download the rest of the asset only if it finds the metadata marker. Additionally, it delays loading the WebAssembly binary until it makes the first processing request.
-- **Adherence to the C2PA specification**: The SDK strives to maintain compliance with the [C2PA specification](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html) as much as possible, and the web components follow the [C2PA user experience guidance](https://c2pa.org/specifications/specifications/1.0/ux/UX_Recommendations.html) recommendations.
-- **Security and encryption**: The SDK handles all [validation](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_validation) via the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) and passes any validation errors back to the client. It supports all ECDSA and RSASSA-PSS algorithms listed in the [C2PA specification](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_digital_signatures).
+- **Adherence to the C2PA specification**: The library strives to maintain compliance with the [C2PA specification](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html) as much as possible, and the web components follow the [C2PA user experience guidance](https://c2pa.org/specifications/specifications/1.0/ux/UX_Recommendations.html) recommendations.
+- **Security and encryption**: The library handles all [validation](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_validation) via the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) and passes any validation errors back to the client. It supports all ECDSA and RSASSA-PSS algorithms listed in the [C2PA specification](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_digital_signatures).
   :::caution
-  The SDK does not currently support Ed25519 signatures.
+  The JavaScript library does not currently support Ed25519 signatures.
   :::caution
 - **Framework-agnostic**: The UI components are [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) that use the [Lit library](https://lit.dev/). Because of this, you can use them in [React, Vue, Angular, Svelte](https://custom-elements-everywhere.com/), or even vanilla JavaScript.
 
 ## Browser support
 
-The SDK uses several modern browser technologies, including:
+The library uses several modern browser technologies, including:
 
 - [WebAssembly](https://webassembly.org/)
 - [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)
@@ -45,9 +45,9 @@ The SDK uses several modern browser technologies, including:
 - [Typed arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays)
 - [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 
-Because of these requirements, **the SDK is not supported on any version of Internet Explorer and on a few less-used mobile browsers**. The chart below from [caniuse.com](https://caniuse.com/wasm,webworkers,cryptography,typedarrays,fetch) summarizes the browsers and versions that support the SDK.
+Because of these requirements, **the library is not supported on any version of Internet Explorer and on a few less-used mobile browsers**. The chart below from [caniuse.com](https://caniuse.com/wasm,webworkers,cryptography,typedarrays,fetch) summarizes the browsers and versions that support the library.
 
-![CAI JavaScript SDK browser support](../../../static/img/caniuse.png)
+![CAI JavaScript library browser support](../../../static/img/caniuse.png)
 
 :::info
 This chart is accurate as of September, 2023. For the most up-to-date browser support information, see [caniuse.com](https://caniuse.com/wasm,webworkers,cryptography,typedarrays,fetch).
@@ -55,7 +55,7 @@ This chart is accurate as of September, 2023. For the most up-to-date browser su
 
 ## Debugging
 
-The JavaScript SDK uses the [debug-js](https://github.com/debug-js/debug) library to get debug-level information under the `c2pa` namespace.
+The JavaScript library uses the [debug-js](https://github.com/debug-js/debug) library to get debug-level information under the `c2pa` namespace.
 
 To view debug messages in the console, use your browser's inspector, go to the Console tab, and enter:
 

--- a/docs/js-sdk/getting-started/quick-start.mdx
+++ b/docs/js-sdk/getting-started/quick-start.mdx
@@ -26,9 +26,9 @@ brew install node@16
 For more advanced JavaScript development, instead of Homebrew, use [nvm](https://github.com/nvm-sh/nvm) to quickly install and use different versions of Node.js.
 :::
 
-## Bringing in the SDK library
+## Bringing in the JavaScript library
 
-You can bring in the SDK library by using a content delivery network (CDN) or by hosting the files yourself.
+You can bring in the JavaScript library by using a content delivery network (CDN) or by hosting the files yourself.
 
 ### Using a CDN
 

--- a/docs/js-sdk/guides/hosting.mdx
+++ b/docs/js-sdk/guides/hosting.mdx
@@ -6,9 +6,9 @@ title: Hosting C2PA assets
 ## Cross-origin (CORS) support
 
 Processing images from a URL or DOM selector requires the
-client to download the source image for processing. If the image is not on the [same origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) as the site running the SDK, the server hosting the images must return the following HTTP response headers for cross-origin resource sharing [(CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS):
+client to download the source image for processing. If the image is not on the [same origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) as the site running the JavaScript library, the server hosting the images must return the following HTTP response headers for cross-origin resource sharing [(CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS):
 
-- [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) must either return the origin of the server running the SDK, or `*` to allow all origins from requests without credentials.
+- [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) must either return the origin of the server running the JavaScript library, or `*` to allow all origins from requests without credentials.
 - [`Access-Control-Allow-Methods`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods) must include at least the `GET` method.
 - [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) must include include `Range` to support [Range requests](#range-requests), in addition to the `Accept-Ranges: bytes` header itself.
 
@@ -16,7 +16,7 @@ The vast majority of major CDNs and hosting providers allow customizing these he
 
 ### Range requests
 
-Since images can be quite large, the SDK uses [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to download the first part of the file (by default, the first 64KB). It then tests if C2PA manifest data exists in this downloaded fragment; if it does, the download proceeds and the SDK processes the rest of the file. This avoids downloading potentially large amounts of data if an image does not contain a manifest.
+Since images can be quite large, the JavaScript library uses [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to download the first part of the file (by default, the first 64KB). It then tests if C2PA manifest data exists in this downloaded fragment; if it does, the download proceeds and the JavaScript library processes the rest of the file. This avoids downloading potentially large amounts of data if an image does not contain a manifest.
 
 For this feature to work, the server hosting the images must support HTTP range requests. To check, open
 your terminal and enter the following command (assuming you have [curl](https://curl.se/) installed):
@@ -32,7 +32,7 @@ Content-Length: 86405
 
 If the response contains `Accept-Ranges: bytes`, then your server is set up to take advantage of this feature.
 
-If the response contains `Accept-Ranges: none` or no `Accept-Ranges` field in the header, the SDK will automatically re-request the image without the `Range` header, forcing a full download of the file.
+If the response contains `Accept-Ranges: none` or no `Accept-Ranges` field in the header, the JavaScript library will automatically re-request the image without the `Range` header, forcing a full download of the file.
 
 ## Library assets
 
@@ -57,5 +57,5 @@ const c2pa = await createC2pa({
 Where `your_static_asset_uri` is the URI where you're serving the library asset files.
 
 :::caution
-When hosting the library files, make sure you are using the correct version number that aligns with the version of the SDK you're using.
+When hosting the library files, make sure you are using the correct version number that aligns with the version of the library you're using.
 :::

--- a/docs/js-sdk/guides/validation.mdx
+++ b/docs/js-sdk/guides/validation.mdx
@@ -19,7 +19,7 @@ Manifest validation errors can occur when:
 
 [Ingredients](../../introduction#key-concepts) are validated when they are imported into an asset. The results of this are stored in the manifest in the ingredient's [`validationStatus`](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_existing_manifests) object, which contains both [success](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_success_codes) and [failure](https://c2pa.org/specifications/specifications/1.3/specs/C2PA_Specification.html#_failure_codes) codes that represent the results of all of the validation checks that took place.
 
-In the JavaScript SDK, you can access validation errors in ingredients like this:
+Access validation errors in ingredients in JavaScript code as follows:
 
 ```typescript
 manifest.ingredients.forEach((ingredient) => {

--- a/docs/js-sdk/guides/viewing-provenance.mdx
+++ b/docs/js-sdk/guides/viewing-provenance.mdx
@@ -6,7 +6,7 @@ hide_table_of_contents: true
 
 import Sandbox from '../../../src/components/Sandbox';
 
-## Initializing the SDK
+## Initializing the library
 
 The way that you import `wasmSrc` and `workerSrc` varies depending on the build system you use. For more information, see [Quick start](../getting-started/quick-start#bringing-in-the-library).
 
@@ -18,7 +18,7 @@ The [`manifestStore`](../../js-sdk/api/c2pa.c2pareadresult.manifeststore) object
 
 - **manifests**: An object containing _all_ manifests found in an asset, keyed by UUID.
 - **activeManifest**: A pointer to the latest [`manifest`](../../js-sdk/api/c2pa.manifest) in the manifest store. Effectively the "parent" manifest, this is the likely starting point when inspecting an asset's C2PA data.
-- **validationStatus**: A list of any validation errors the SDK generated when processing an asset. See [Validation](./validation) for more information.
+- **validationStatus**: A list of any validation errors the library generated when processing an asset. See [Validation](./validation) for more information.
 
 [`Manifest`](../../js-sdk/api/c2pa.manifest) objects contain properties pertaining to an asset's provenance, along with convenient interfaces for [accessing assertion data](../../js-sdk/api/c2pa.assertionaccessor) and [generating a thumbnail](../../js-sdk/api/c2pa.thumbnail). The example in this sandbox demonstrates a basic workflow: reading a sample image, checking for the presence of a manifest store, and displaying the data in the active manifest:
 


### PR DESCRIPTION
Moving to "JavaScript library" from "JavaScript SDK" to be consistent with rest of docs