### PR TITLE
Update link to c2patool GitHub since it was moved into c2pa-rs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -100,7 +100,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'GitHub',
-          href: 'https://github.com/contentauth/c2patool',
+          href: 'https://github.com/contentauth/c2pa-rs/tree/main/cli',
         },
       ],
     },


### PR DESCRIPTION
## Changes in this pull request

Trivial fix: Change link in sidebar to https://github.com/contentauth/c2pa-rs/tree/main/cli.