### PR TITLE
Replace outdated release notes with current changelog

### DIFF
--- a/docs/c2patool-rns.mdx
+++ b/docs/c2patool-rns.mdx
@@ -1,0 +1,12 @@
+---
+id: c2patool-rns
+title: C2PA Tool release notes
+---
+
+:::info
+For additional release notes for versions 0.9.x and earlier, see [Archived release notes](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/release-notes.md).
+:::
+
+import C2PAToolChangelog from './c2patool/docs/changelog.md';
+
+<C2PAToolChangelog name="C2PATool_changelog" />

--- a/scripts/fetch-readme.js
+++ b/scripts/fetch-readme.js
@@ -75,9 +75,9 @@ const readmes = [
     path: 'cli/docs/x_509.md',
   },
   {
-    dest: resolve(__dirname, '../docs/c2patool/docs/release-notes.md'),
+    dest: resolve(__dirname, '../docs/c2patool/docs/changelog.md'),
     repo: 'contentauth/c2pa-rs',
-    path: 'cli/docs/release-notes.md',
+    path: 'cli/CHANGELOG.md',
   },
   {
     dest: resolve(__dirname, '../docs/c2patool/docs/usage.md'),

--- a/sidebars.js
+++ b/sidebars.js
@@ -89,7 +89,7 @@ const sidebars = {
         },
         {
           type: 'doc',
-          id: 'c2patool/docs/release-notes',
+          id: 'c2patool-rns', // 'c2patool/docs/changelog',
           label: 'Release notes',
         },
         {


### PR DESCRIPTION
The [c2patool release notes](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/release-notes.md) are not being kept up to date.  However, the changelog is. Replace old RNs with changelog in docs.
