### PR TITLE
Add link to docs.rs for TrustMark

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -343,6 +343,11 @@ const sidebars = {
               label: 'Rust CLI',
             },
             {
+              type: 'link',
+              label: 'TrustMark Rust API docs',
+              href: 'https://docs.rs/trustmark',
+            },
+            {
               type: 'doc',
               id: 'durable-cr/tm-faq',
               label: 'FAQ',


### PR DESCRIPTION
Adds link to sidebar nav, similar to c2pa-rs docs.rs link.
