### PR TITLE
Fix testfiles base url

### DIFF
--- a/docs/manifest/examples.mdx
+++ b/docs/manifest/examples.mdx
@@ -7,7 +7,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 ## C2PA test files
 
-The C2PA [public-testfiles](https://github.com/c2pa-org/public-testfiles) repository contains numerous examples of asset files with Content Credentials. See https://c2pa.org/public-testfiles/ for links to easily inspect each asset file using Verify using [an asset URL](../verify.mdx#using-an-asset-url) and to the corresponding [manifest report](../c2patool/docs/usage.md#displaying-manifest-data) and [detailed manifest report](../c2patool/docs/usage.md#detailed-manifest-report) from C2PA Tool.
+The C2PA [public-testfiles](https://github.com/c2pa-org/public-testfiles) repository contains numerous examples of asset files with Content Credentials. See https://spec.c2pa.org/public-testfiles/ for links to easily inspect each asset file using Verify using [an asset URL](../verify.mdx#using-an-asset-url) and to the corresponding [manifest report](../c2patool/docs/usage.md#displaying-manifest-data) and [detailed manifest report](../c2patool/docs/usage.md#detailed-manifest-report) from C2PA Tool.
 
 :::note
 The claims on these test files were signed with C2PA Tool's built-in test certificate and key (which is not on the [known certificate list](../trust-list.mdx)). Thus, Verify will display the warning: "The Content Credential issuer couldn’t be recognized. This file may not come from where it claims to."

--- a/docs/manifest/ingredients.md
+++ b/docs/manifest/ingredients.md
@@ -58,8 +58,8 @@ The ingredient object's `relationship` property describes its relationship to th
 ## Validation status
 
 When ingredients are added, the SDK validates their Content Credentials (if any).  However, the validation status of an ingredient does not imply anything about the validation status of the composed asset containing the ingredient. In other words:
-- A composed asset's Content Credentials may be valid, but one or more of its ingredients may have invalid Content Credentials. For example, test file [adobe-20220124-XCA.jpg](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-XCA.jpg)
-- A composed asset's Content Credentials may be invalid, but one or more of its ingredients may have valid Content Credentials. For example, test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg). 
+- A composed asset's Content Credentials may be valid, but one or more of its ingredients may have invalid Content Credentials. For example, test file [adobe-20220124-XCA.jpg](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-XCA.jpg)
+- A composed asset's Content Credentials may be invalid, but one or more of its ingredients may have valid Content Credentials. For example, test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg). 
 
 :::note
 Ingredient certificates are validated when they are added to the manifest store, NOT during validation of the composed asset. 
@@ -67,7 +67,7 @@ Ingredient certificates are validated when they are added to the manifest store,
 
 ### Example of ingredient with invalid credentials
 
-As noted above, the test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg) has an ingredient with invalid Content Credentials, as shown in this snippet from the manifest store: 
+As noted above, the test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg) has an ingredient with invalid Content Credentials, as shown in this snippet from the manifest store: 
 
 ```json
 ...
@@ -106,9 +106,9 @@ As noted above, the test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcre
 
 ## Examples
 
-The [C2PA public-testfiles](https://c2pa.org/public-testfiles/image/) repository has several examples of images with multiple ingredients:
-- [Image with two ingredients](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICA.jpg); [View JSON manifest store](https://c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAICA/manifest_store.json)
-- [Image with seven ingredients](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAIAIIICAICIICAIICICA.jpg); [View JSON manifest store](https://c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAIAIIICAICIICAIICICA/manifest_store.json)
+The [C2PA public-testfiles](https://spec.c2pa.org/public-testfiles/image/) repository has several examples of images with multiple ingredients:
+- [Image with two ingredients](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICA.jpg); [View JSON manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAICA/manifest_store.json)
+- [Image with seven ingredients](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAIAIIICAICIICAIICICA.jpg); [View JSON manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAIAIIICAICIICAIICICA/manifest_store.json)
 
 
 

--- a/docs/manifest/ingredients.md
+++ b/docs/manifest/ingredients.md
@@ -15,9 +15,9 @@ The C2PA Technical Specification describes _ingredient assertions_ but the CAI S
 
 ## Ingredient objects
 
-Each ingredient used to create an asset is listed in the [JSON manifest](manifest-ref.mdx) `ingredients` array.  When an ingredient itself has Content Credentials, those manifests are included in the composed asset's manifest store to keep the provenance data intact. 
+Each ingredient used to create an asset is listed in the [JSON manifest](manifest/json-ref/manifest-def.mdx) `ingredients` array.  When an ingredient itself has Content Credentials, those manifests are included in the composed asset's manifest store to keep the provenance data intact. 
 
-The `ingredients` array contains an [ingredient object](manifest-ref.mdx#ingredient) for each ingredient.  The only required property of the `ingredient` object is the `title` property, which usually is the source file name.
+The `ingredients` array contains an [ingredient object](manifest/json-ref/manifest-def.mdx#ingredient) for each ingredient.  The only required property of the `ingredient` object is the `title` property, which usually is the source file name.
 
 Other important properties of the ingredient object include:
 - `format`: MIME type of the source file.

--- a/docs/verify.mdx
+++ b/docs/verify.mdx
@@ -46,7 +46,7 @@ https://contentcredentials.org/verify?source=<ASSET_URL>
 
 where `<ASSET_URL>` is the URL of the asset.
 
-For example: https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CICA.jpg
+For example: https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CICA.jpg
 
 :::note
 To use Verify on an asset URL, the URL must not require any authentication and the hosting server must allow cross-origin resource sharing (CORS) in the `Access-Control-Allow-Origin` HTTP response header.
@@ -54,9 +54,9 @@ To use Verify on an asset URL, the URL must not require any authentication and t
 
 ### C2PA test files
 
-The [C2PA public-testfiles](https://c2pa.org/public-testfiles/image/) repository contains image files that demonstrate Content Credentials, including multiple ingredients, Exif metadata, and various error conditions, along with links to inspect the assets using Verify and to view the corresponding manifest reports from the [C2PA Tool](c2patool).
+The [C2PA public-testfiles](https://spec.c2pa.org/public-testfiles/image/) repository contains image files that demonstrate Content Credentials, including multiple ingredients, Exif metadata, and various error conditions, along with links to inspect the assets using Verify and to view the corresponding manifest reports from the [C2PA Tool](c2patool).
 
-Currently, most of the asset files in the repository are JPEG images, but a few [PDF](https://c2pa.org/public-testfiles/pdf/) and [video](https://c2pa.org/public-testfiles/video/) test files are also available.
+Currently, most of the asset files in the repository are JPEG images, but a few [PDF](https://spec.c2pa.org/public-testfiles/pdf/) and [video](https://spec.c2pa.org/public-testfiles/video/) test files are also available.
 
 ## Information displayed
 
@@ -206,7 +206,7 @@ import verify_validation_error from '../static/img/verify-validation-error.png';
   style={{ width: '300px', display: 'block', margin: '10px auto' }}
 />
 
-Verify displays this warning if the `validation_status` array contains any elements. For example, a [this image](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-dat-CA.jpg) with a hard binding hash mismatch error, as shown in [this manifest store](https://c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-dat-CA/manifest_store.json):
+Verify displays this warning if the `validation_status` array contains any elements. For example, a [this image](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-dat-CA.jpg) with a hard binding hash mismatch error, as shown in [this manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-dat-CA/manifest_store.json):
 
 ```
 "validation_status": [
@@ -218,7 +218,7 @@ Verify displays this warning if the `validation_status` array contains any eleme
   ]
 ```
 
-Another example that can result in this message is shown in [this image](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-clm-CAICAI.jpg) with a missing referenced claim, as shown in [this manifest store](https://c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-clm-CAICAI/manifest_store.json):
+Another example that can result in this message is shown in [this image](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-clm-CAICAI.jpg) with a missing referenced claim, as shown in [this manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-clm-CAICAI/manifest_store.json):
 
 ```
 "validation_status": [
@@ -252,8 +252,8 @@ import verify_process from '../static/img/verify-process.png';
 
 See the above example yourself, based on a C2PA test image:
 
-- [Inspect using Verify](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICAI.jpg)
-- [View the corresponding manifest report from C2PA Tool](https://c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAICAI/manifest_store.json)
+- [Inspect using Verify](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICAI.jpg)
+- [View the corresponding manifest report from C2PA Tool](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAICAI/manifest_store.json)
 
 #### App or device used
 
@@ -403,5 +403,5 @@ The Exif metadata assertions from the JSON manifest for the above example is sho
 
 See the above example yourself, based on a C2PA test image:
 
-- [Inspect using Verify](https://contentcredentials.org/verify?source=https://c2pa.org/public-testfiles/image/jpeg/truepic-20230212-camera.jpg)
-- [View the corresponding manifest report from C2PA Tool](https://c2pa.org/public-testfiles/image/jpeg/manifests/truepic-20230212-camera/manifest_store.json)
+- [Inspect using Verify](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/truepic-20230212-camera.jpg)
+- [View the corresponding manifest report from C2PA Tool](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/truepic-20230212-camera/manifest_store.json)


### PR DESCRIPTION
Base URL of https://c2pa.org/public-testfiles/ changed to 
https://spec.c2pa.org/public-testfiles/