### PR TITLE
Change URL of Verify site

### DIFF
--- a/docs/conformance.mdx
+++ b/docs/conformance.mdx
@@ -84,7 +84,7 @@ C2PA maintains two trust lists:
 With the introduction of the C2PA trust list, the existing [interim (temporary) trust list](trust-list.mdx) is being retired on the following timeline:
 
 - **Through December 31, 2025**: The [interim trust list](trust-list.mdx) will remain operational. During this time:
-  - The [Verify site](https://contentcredentials.org/verify) will continue to display manifests signed by certificates on the interim trust list as trusted, but with a disclaimer that the manifests were made with an older version of the trust model.
+  - The [Verify site](https://verify.contentauthenticity.org) will continue to display manifests signed by certificates on the interim trust list as trusted, but with a disclaimer that the manifests were made with an older version of the trust model.
   - New certificates will continue to be added to the interim trust list when requested.
   - Product developers are strongly encouraged to apply to the C2PA conformance program and use the official C2PA trust list.
 - **On January 1, 2026**: The interim trust list will be frozen:

--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -31,7 +31,7 @@ Notable implementations using blockchain:
 
 ### Are Content Credentials about digital rights management?
 
-No; Content Credentials do not enforce permissions for access to content. In many cases, the name displayed on the [Verify website](https://contentcredentials.org/verify) is the name of the exporter of the content, not the rights owner.
+No; Content Credentials do not enforce permissions for access to content. In many cases, the name displayed on the [Verify website](https://verify.contentauthenticity.org) is the name of the exporter of the content, not the rights owner.
 
 The ["Produced by" section](verify.mdx#produced-by) in Verify refers to the name of the exporter. If the image was created with an Adobe Product such as Photoshop with Content Credentials (Beta) enabled, the "Produced by" section shows the name of the Adobe ID associated with the user who exported the image.
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -94,7 +94,7 @@ For more information on getting and using certificates, see [Signing and certifi
 
 import verify_unknown_source from '../static/img/verify-cc-unknown-source.png';
 
-The C2PA [Verify tool](https://contentcredentials.org/verify) uses a list of _known certificates_ (sometimes referred to as a "trust list") to determine whether a Content Credential was issued by a known source. The known certificate list applies only to [Verify ](https://contentcredentials.org/verify). For more information, see [Verify tool known certificate list](verify-known-cert-list)
+The C2PA [Verify tool](https://verify.contentauthenticity.org) uses a list of _known certificates_ (sometimes referred to as a "trust list") to determine whether a Content Credential was issued by a known source. The known certificate list applies only to [Verify](https://verify.contentauthenticity.org). For more information, see [Verify tool known certificate list](verify-known-cert-list)
 
 ## Identity
 

--- a/docs/includes/_moreinfo_table.md
+++ b/docs/includes/_moreinfo_table.md
@@ -3,5 +3,5 @@
 | -------- | ------------- | ---------------------- |
 | [c2pa.org](https://c2pa.org/) | C2PA / Linux Foundation | Standards body<br/>Technical specifications and guidance documents |
 | [contentcredentials.org](https://contentcredentials.org/) | C2PA | Consumer-friendly site  |
-| [Verify](https://contentcredentials.org/verify) | C2PA | Web-based tool to display Content Credentials. <br/> For more information, see [Using the Verify tool](verify) |
+| [Verify](https://verify.contentauthenticity.org) | C2PA | Web-based tool to display Content Credentials. <br/> For more information, see [Using the Verify tool](verify) |
 | [contentauthenticity.org](https://contentauthenticity.org/) | CAI | Industry consortium<br/>Open-source software and community resources  |

--- a/docs/manifest/reading/ingredients-reading.md
+++ b/docs/manifest/reading/ingredients-reading.md
@@ -77,8 +77,8 @@ The ingredient object's `relationship` property describes its relationship to th
 The [ValidationResults](/docs/manifest/json-ref/reader#validationresults) object contains the the validation results for the active manifest and any changes to ingredients.
 
 When ingredients are added, the SDK validates their Content Credentials (if any).  However, the validation status of an ingredient does not imply anything about the validation status of the composed asset containing the ingredient. In other words:
-- A composed asset's Content Credentials may be valid, but one or more of its ingredients may have invalid Content Credentials. For example, test file [adobe-20220124-XCA.jpg](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-XCA.jpg)
-- A composed asset's Content Credentials may be invalid, but one or more of its ingredients may have valid Content Credentials. For example, test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg). 
+- A composed asset's Content Credentials may be valid, but one or more of its ingredients may have invalid Content Credentials. For example, test file [adobe-20220124-XCA.jpg](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-XCA.jpg)
+- A composed asset's Content Credentials may be invalid, but one or more of its ingredients may have valid Content Credentials. For example, test file [adobe-20220124-CIE-sig-CA.jpg](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg). 
 
 :::note
 Ingredient certificates are validated when they are added to the manifest store, NOT during validation of the composed asset. 
@@ -86,7 +86,7 @@ Ingredient certificates are validated when they are added to the manifest store,
 
 ### Example of ingredient with invalid credentials
 
-As noted above, the test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg) has an ingredient with invalid Content Credentials, as shown in this snippet from the manifest store: 
+As noted above, the test file [adobe-20220124-CIE-sig-CA.jpg](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CIE-sig-CA.jpg) has an ingredient with invalid Content Credentials, as shown in this snippet from the manifest store: 
 
 ```json
 ...
@@ -126,5 +126,5 @@ As noted above, the test file [adobe-20220124-CIE-sig-CA.jpg](https://contentcre
 ## Examples
 
 The [C2PA public-testfiles](https://spec.c2pa.org/public-testfiles/image/) repository has several examples of images with multiple ingredients:
-- [Image with two ingredients](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICA.jpg); [View JSON manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAICA/manifest_store.json)
-- [Image with seven ingredients](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAIAIIICAICIICAIICICA.jpg); [View JSON manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAIAIIICAICIICAIICICA/manifest_store.json)
+- [Image with two ingredients](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICA.jpg); [View JSON manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAICA/manifest_store.json)
+- [Image with seven ingredients](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAIAIIICAICIICAIICICA.jpg); [View JSON manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAIAIIICAICIICAIICICA/manifest_store.json)

--- a/docs/signing/local-signing.md
+++ b/docs/signing/local-signing.md
@@ -157,5 +157,5 @@ This command displays the manifest attached to `signed_image.jpg` and should inc
 ```
 
 :::info
-You can also use [Verify](https://contentcredentials.org/verify) to confirm that your image was signed, but if you used a personal certificate (not an organization certificate) then [Verify won't show the organization name](get-cert.md#organization-name) and if your certificate is not on the [known certificate list](../trust-list.mdx), Verify [displays the message](../verify.mdx#title-and-signing-information) "The Content Credential issuer couldn't be recognized...."
+You can also use [Verify](https://verify.contentauthenticity.org) to confirm that your image was signed, but if you used a personal certificate (not an organization certificate) then [Verify won't show the organization name](get-cert.md#organization-name) and if your certificate is not on the [known certificate list](../trust-list.mdx), Verify [displays the message](../verify.mdx#title-and-signing-information) "The Content Credential issuer couldn't be recognized...."
 :::

--- a/docs/trust-list.mdx
+++ b/docs/trust-list.mdx
@@ -9,7 +9,7 @@ import verify_unknown_source from '../static/img/verify-cc-unknown-source.png';
 The process described on this page is deprecated. The C2PA has released its official trust lists, and Verify will be updated to use them soon. See [Deprecation timeline](#deprecation-timeline) for more information.
 :::
 
-The C2PA **[Verify tool](https://contentcredentials.org/verify)** uses a list of _known certificates_ (sometimes referred to as a "trust list") to determine whether a Content Credential was issued by a known source. If an asset's Content Credential was not signed by a known certificate, the Verify tool will display this message:
+The C2PA **[Verify tool](https://verify.contentauthenticity.org)** uses a list of _known certificates_ (sometimes referred to as a "trust list") to determine whether a Content Credential was issued by a known source. If an asset's Content Credential was not signed by a known certificate, the Verify tool will display this message:
 
 <img
   src={verify_unknown_source}
@@ -21,7 +21,7 @@ Conversely, if the Content Credential was signed by a known certificate, the Ver
 ## Deprecation timeline
 
 :::note
-Currently, **[Verify](https://contentcredentials.org/verify)** uses the interim trust list described here (also referred to as the _temporary trust list_), but Verify will be updated soon to use the official [C2PA trust list](conformance.mdx#c2pa-trust-lists).
+Currently, **[Verify](https://verify.contentauthenticity.org)** uses the interim trust list described here (also referred to as the _temporary trust list_), but Verify will be updated soon to use the official [C2PA trust list](conformance.mdx#c2pa-trust-lists).
 :::
 
 The interim trust list (also known as the _temporary trust list_) will remain operational **through December 31, 2025**. During this time, C2PA will continue to accept new certificates following the process described below. At some point, the Verify site will distinguish between Content Credentials from conforming products and those signed using certificates on the interim trust list.

--- a/docs/verify.mdx
+++ b/docs/verify.mdx
@@ -5,7 +5,7 @@ title: Using the Verify tool
 
 import verify_site from '../static/img/verify.png';
 
-The C2PA **[Verify tool](https://contentcredentials.org/verify)** (often referred to as simply "Verify") is useful both for consumers and for CAI application developers.
+The C2PA **[Verify tool](https://verify.contentauthenticity.org)** (often referred to as simply "Verify") is useful both for consumers and for CAI application developers.
 
 <img
   src={verify_site}
@@ -41,12 +41,12 @@ Click **Select a file from your device** then use the native picker or drag and 
 You can also display Content Credentials for an asset with a publicly-visible URL by using a URL with the following format:
 
 ```
-https://contentcredentials.org/verify?source=<ASSET_URL>
+https://verify.contentauthenticity.org?source=<ASSET_URL>
 ```
 
 where `<ASSET_URL>` is the URL of the asset.
 
-For example: https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CICA.jpg
+For example: https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CICA.jpg
 
 :::note
 To use Verify on an asset URL, the URL must not require any authentication and the hosting server must allow cross-origin resource sharing (CORS) in the `Access-Control-Allow-Origin` HTTP response header.
@@ -206,7 +206,7 @@ import verify_validation_error from '../static/img/verify-validation-error.png';
   style={{ width: '300px', display: 'block', margin: '10px auto' }}
 />
 
-Verify displays this warning if the `validation_status` array contains any elements. For example, a [this image](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-dat-CA.jpg) with a hard binding hash mismatch error, as shown in [this manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-dat-CA/manifest_store.json):
+Verify displays this warning if the `validation_status` array contains any elements. For example, a [this image](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-dat-CA.jpg) with a hard binding hash mismatch error, as shown in [this manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-dat-CA/manifest_store.json):
 
 ```
 "validation_status": [
@@ -218,7 +218,7 @@ Verify displays this warning if the `validation_status` array contains any eleme
   ]
 ```
 
-Another example that can result in this message is shown in [this image](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-clm-CAICAI.jpg) with a missing referenced claim, as shown in [this manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-clm-CAICAI/manifest_store.json):
+Another example that can result in this message is shown in [this image](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-E-clm-CAICAI.jpg) with a missing referenced claim, as shown in [this manifest store](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-E-clm-CAICAI/manifest_store.json):
 
 ```
 "validation_status": [
@@ -252,7 +252,7 @@ import verify_process from '../static/img/verify-process.png';
 
 See the above example yourself, based on a C2PA test image:
 
-- [Inspect using Verify](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICAI.jpg)
+- [Inspect using Verify](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/adobe-20220124-CAICAI.jpg)
 - [View the corresponding manifest report from C2PA Tool](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/adobe-20220124-CAICAI/manifest_store.json)
 
 #### App or device used
@@ -403,5 +403,5 @@ The Exif metadata assertions from the JSON manifest for the above example is sho
 
 See the above example yourself, based on a C2PA test image:
 
-- [Inspect using Verify](https://contentcredentials.org/verify?source=https://spec.c2pa.org/public-testfiles/image/jpeg/truepic-20230212-camera.jpg)
+- [Inspect using Verify](https://verify.contentauthenticity.org?source=https://spec.c2pa.org/public-testfiles/image/jpeg/truepic-20230212-camera.jpg)
 - [View the corresponding manifest report from C2PA Tool](https://spec.c2pa.org/public-testfiles/image/jpeg/manifests/truepic-20230212-camera/manifest_store.json)


### PR DESCRIPTION
## Changes in this pull request

Update the URL of Verify from `https://contentcredentials.org/verify` to `https://verify.contentauthenticity.org` everywhere. 


