### PR TITLE
ci: update doc schemas on c2pa-rs release

### DIFF
--- a/.github/workflows/update-schemas.yml
+++ b/.github/workflows/update-schemas.yml
@@ -47,7 +47,14 @@ jobs:
         run: cargo run --bin export_schema
 
       - name: Move new schemas into ./json-manifest-reference/_data
-        run: cp ./c2pa-rs/target/schema/* ./json-manifest-reference/_data/
+        run: |
+          # We also rename the schemas to have an underscore in the filename instead of a dot to fix
+          # compatibility issues with Ruby/Jekyll.
+          for path in ./c2pa-rs/target/schema/*.schema.json; do
+            name=$(basename "$path")
+            new=${name/.schema/_schema}
+            cp "$path" "./json-manifest-reference/_data/$new"
+          done
 
       - name: Check schemas for diff
         id: diffs


### PR DESCRIPTION
Builds off https://github.com/contentauth/json-manifest-reference/pull/28 to automatically update JSON schemas on the doc website per new c2pa-rs release.

See example PR of updated HTML: https://github.com/ok-nick/opensource.contentauth.org/pull/1

* Blocked by https://github.com/contentauth/c2pa-rs/pull/1521