### PR TITLE
fix: search button overlap menu on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -346,6 +346,11 @@ body:not(.is-scrolling) .navbar {
     flex-flow: row-reverse;
     justify-content: space-between;
   }
+
+  /* https://github.com/contentauth/opensource.contentauth.org/issues/248 */
+  [class*='navbarSearchContainer'] {
+    right: calc(var(--ifm-navbar-padding-horizontal) + 44px) !important;
+  }
 }
 
 /*  Admonitions */


### PR DESCRIPTION
Fixes the search button overlap of the menu button on mobile.

- Closes #248

New layout:
<img width="404" height="870" alt="Screenshot 2026-04-15 at 4 22 21 PM" src="https://github.com/user-attachments/assets/0be7af36-90ec-40b8-b914-3cb3717b70a2" />
