### PR TITLE
Add Cursor/Claude skill for tech doc edits

### DIFF
--- a/.claude/skills/edit-doc/SKILL.md
+++ b/.claude/skills/edit-doc/SKILL.md
@@ -20,6 +20,14 @@ All headings should use sentence case.
 
 Do not use hyperlinks in headings. If needed, move the link into a sentence in the heading's section.
 
+## Use titles for hyperlink text
+
+When hyperlinking, use the title of the target document or section as the link text.  Never use "this" or "see here" as the link text.
+
+## Check hyperlinks
+
+Make sure that all hyperlinks resolve correctly.
+
 ## Keep headings brief
 
 Long headings do not work well in a page table of contents, so keep headings brief, yet meaningful.  Do not use parenthesis in headings if possible.
@@ -30,7 +38,7 @@ Only proper nouns should be capitalized.  Feature names, UI elements, and other 
 
 ## Code font
 
-Code elements such as object, method, and property names should be in code (monospace) font, that is, enclosed in back tick (`) characters.  Also use code font for for file names and directory paths.
+Code elements such as object, method, and property names should be in code (monospace) font, that is, in markdown enclosed in back tick (`) characters.  Also use code font for for file names and directory paths.
 
 But do not follow this rule in headings.  In other words, do not use code font in headings.
 
@@ -40,7 +48,11 @@ Always use active voice, unless it makes a sentence awkward.
 
 ## Avoid duplication
 
-Don't repeat the same information, unless there is a very good reason to do so. In cases where the duplication is blatant, remove them.  Otherwise, flag them for review.
+Don't repeat the same information, unless there is a very good reason to do so. In cases where the duplication is blatant, remove it.  Otherwise, flag for review.
+
+## Avoid very long sentences
+
+Try not to use sentences that are inordinately long.  Prefer short, direct, easy-to-understand sentences when possible.
 
 ## Numbers
 
@@ -58,6 +70,14 @@ Use bold for user interface elements such as button or link text, essentially an
 
 If any horizontal rules are placed between sections, remove them.
 
+## Use bullet lists for three or more items in sequence
+
+When listing three or more things in a sequence, put each item into a bullet list item.  If the things have an order, use an ordered (numbered) list.
+
+## Do not use a numbered list for unordered items
+
+For lists that do not have a specified order, use a bullet (unordered) list instead of a numbered (ordered) list.
+
 ## Avoid em-dashes when possible
 
 Use other punctuation for interjections.  In many cases, a colon works for a phrase delimited by an em-dash at the end of a sentence.
@@ -69,12 +89,12 @@ Make sure spelling is correct, and flag any uncommon words.
 ## Use Docusaurus admonitions in the contentauth/opensource.contentauth.org repository
 
 For documents in the contentauth/opensource.contentauth.org repository only, use Docusaurus  admonitions (alerts) for: Note, Info, Tip, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
-:::note
+::: note
 This is the note text.
 :::
 
 # Use GitHub flavored markdown admonitions for all other repositories in the contentauth org
 
-For documents in all other repositories in the contentauth org, use GitHub flavored markdown admonitions (alerts) for: Note, Tip, Important, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
+For documents in repositories other than opensource.contentauth.org in the contentauth org, use GitHub flavored markdown admonitions (alerts) for: Note, Tip, Important, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
 > [!NOTE]
 > This is the note text.

--- a/.claude/skills/edit-doc/SKILL.md
+++ b/.claude/skills/edit-doc/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: edit-doc
+description: Apply style rules when editing technical documentation. Use whenever the user asks to edit, review, clean up, or improve any docs, README, or written technical content.
+---
+# Edit docs
+
+## Overview
+
+This skill provides style and typography guidance for editing technical documentation.
+
+## Glossary
+
+Before starting, fetch the glossary: https://opensource.contentauthenticity.org/docs/getting-started/glossary and apply the terminology and conventions defined there.
+
+## Sentence case headings
+
+All headings should use sentence case.
+
+## No links in headings
+
+Do not use hyperlinks in headings. If needed, move the link into a sentence in the heading's section.
+
+## Keep headings brief
+
+Long headings do not work well in a page table of contents, so keep headings brief, yet meaningful.  Do not use parenthesis in headings if possible.
+
+## Capitalization
+
+Only proper nouns should be capitalized.  Feature names, UI elements, and other things should not be capitalized, except in special cases.  Official product names and code names should be capitalized.
+
+## Code font
+
+Code elements such as object, method, and property names should be in code (monospace) font, that is, enclosed in back tick (`) characters.  Also use code font for for file names and directory paths.
+
+But do not follow this rule in headings.  In other words, do not use code font in headings.
+
+## Active voice
+
+Always use active voice, unless it makes a sentence awkward.
+
+## Avoid duplication
+
+Don't repeat the same information, unless there is a very good reason to do so. In cases where the duplication is blatant, remove them.  Otherwise, flag them for review.
+
+## Numbers
+
+In running text, spell out one through nine; use numerals for 10 and greater. The same rule applies to ordinals: Spell out first through ninth; use numerals for 10th and greater.
+
+## Commas
+
+Use the serial or Oxford comma (a comma preceding "and" or "or" in a list of three or more items) such as "This, that, and the other".
+
+## User interface elements
+
+Use bold for user interface elements such as button or link text, essentially anything that you see on the screen in a UI.
+
+## No horizontal rules separating sections
+
+If any horizontal rules are placed between sections, remove them.
+
+## Avoid em-dashes when possible
+
+Use other punctuation for interjections.  In many cases, a colon works for a phrase delimited by an em-dash at the end of a sentence.
+
+## Always do a basic spell check
+
+Make sure spelling is correct, and flag any uncommon words.
+
+## Use Docusaurus admonitions in the contentauth/opensource.contentauth.org repository
+
+For documents in the contentauth/opensource.contentauth.org repository only, use Docusaurus  admonitions (alerts) for: Note, Info, Tip, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
+:::note
+This is the note text.
+:::
+
+# Use GitHub flavored markdown admonitions for all other repositories in the contentauth org
+
+For documents in all other repositories in the contentauth org, use GitHub flavored markdown admonitions (alerts) for: Note, Tip, Important, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
+> [!NOTE]
+> This is the note text.

--- a/.cursor/skills/edit-doc/SKILL.md
+++ b/.cursor/skills/edit-doc/SKILL.md
@@ -20,6 +20,14 @@ All headings should use sentence case.
 
 Do not use hyperlinks in headings. If needed, move the link into a sentence in the heading's section.
 
+## Use titles for hyperlink text
+
+When hyperlinking, use the title of the target document or section as the link text.  Never use "this" or "see here" as the link text.
+
+## Check hyperlinks
+
+Make sure that all hyperlinks resolve correctly.
+
 ## Keep headings brief
 
 Long headings do not work well in a page table of contents, so keep headings brief, yet meaningful.  Do not use parenthesis in headings if possible.
@@ -30,7 +38,7 @@ Only proper nouns should be capitalized.  Feature names, UI elements, and other 
 
 ## Code font
 
-Code elements such as object, method, and property names should be in code (monospace) font, that is, enclosed in back tick (`) characters.  Also use code font for for file names and directory paths.
+Code elements such as object, method, and property names should be in code (monospace) font, that is, in markdown enclosed in back tick (`) characters.  Also use code font for for file names and directory paths.
 
 But do not follow this rule in headings.  In other words, do not use code font in headings.
 
@@ -40,7 +48,11 @@ Always use active voice, unless it makes a sentence awkward.
 
 ## Avoid duplication
 
-Don't repeat the same information, unless there is a very good reason to do so. In cases where the duplication is blatant, remove them.  Otherwise, flag them for review.
+Don't repeat the same information, unless there is a very good reason to do so. In cases where the duplication is blatant, remove it.  Otherwise, flag for review.
+
+## Avoid very long sentences
+
+Try not to use sentences that are inordinately long.  Prefer short, direct, easy-to-understand sentences when possible.
 
 ## Numbers
 
@@ -58,6 +70,14 @@ Use bold for user interface elements such as button or link text, essentially an
 
 If any horizontal rules are placed between sections, remove them.
 
+## Use bullet lists for three or more items in sequence
+
+When listing three or more things in a sequence, put each item into a bullet list item.  If the things have an order, use an ordered (numbered) list.
+
+## Do not use a numbered list for unordered items
+
+For lists that do not have a specified order, use a bullet (unordered) list instead of a numbered (ordered) list.
+
 ## Avoid em-dashes when possible
 
 Use other punctuation for interjections.  In many cases, a colon works for a phrase delimited by an em-dash at the end of a sentence.
@@ -69,12 +89,12 @@ Make sure spelling is correct, and flag any uncommon words.
 ## Use Docusaurus admonitions in the contentauth/opensource.contentauth.org repository
 
 For documents in the contentauth/opensource.contentauth.org repository only, use Docusaurus  admonitions (alerts) for: Note, Info, Tip, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
-:::note
+::: note
 This is the note text.
 :::
 
 # Use GitHub flavored markdown admonitions for all other repositories in the contentauth org
 
-For documents in all other repositories in the contentauth org, use GitHub flavored markdown admonitions (alerts) for: Note, Tip, Important, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
+For documents in repositories other than opensource.contentauth.org in the contentauth org, use GitHub flavored markdown admonitions (alerts) for: Note, Tip, Important, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
 > [!NOTE]
 > This is the note text.

--- a/.cursor/skills/edit-doc/SKILL.md
+++ b/.cursor/skills/edit-doc/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: edit-doc
+description: Apply style rules when editing technical documentation. Use whenever the user asks to edit, review, clean up, or improve any docs, README, or written technical content.
+---
+# Edit docs
+
+## Overview
+
+This skill provides style and typography guidance for editing technical documentation.
+
+## Glossary
+
+Before starting, fetch the glossary: https://opensource.contentauthenticity.org/docs/getting-started/glossary and apply the terminology and conventions defined there.
+
+## Sentence case headings
+
+All headings should use sentence case.
+
+## No links in headings
+
+Do not use hyperlinks in headings. If needed, move the link into a sentence in the heading's section.
+
+## Keep headings brief
+
+Long headings do not work well in a page table of contents, so keep headings brief, yet meaningful.  Do not use parenthesis in headings if possible.
+
+## Capitalization
+
+Only proper nouns should be capitalized.  Feature names, UI elements, and other things should not be capitalized, except in special cases.  Official product names and code names should be capitalized.
+
+## Code font
+
+Code elements such as object, method, and property names should be in code (monospace) font, that is, enclosed in back tick (`) characters.  Also use code font for for file names and directory paths.
+
+But do not follow this rule in headings.  In other words, do not use code font in headings.
+
+## Active voice
+
+Always use active voice, unless it makes a sentence awkward.
+
+## Avoid duplication
+
+Don't repeat the same information, unless there is a very good reason to do so. In cases where the duplication is blatant, remove them.  Otherwise, flag them for review.
+
+## Numbers
+
+In running text, spell out one through nine; use numerals for 10 and greater. The same rule applies to ordinals: Spell out first through ninth; use numerals for 10th and greater.
+
+## Commas
+
+Use the serial or Oxford comma (a comma preceding "and" or "or" in a list of three or more items) such as "This, that, and the other".
+
+## User interface elements
+
+Use bold for user interface elements such as button or link text, essentially anything that you see on the screen in a UI.
+
+## No horizontal rules separating sections
+
+If any horizontal rules are placed between sections, remove them.
+
+## Avoid em-dashes when possible
+
+Use other punctuation for interjections.  In many cases, a colon works for a phrase delimited by an em-dash at the end of a sentence.
+
+## Always do a basic spell check
+
+Make sure spelling is correct, and flag any uncommon words.
+
+## Use Docusaurus admonitions in the contentauth/opensource.contentauth.org repository
+
+For documents in the contentauth/opensource.contentauth.org repository only, use Docusaurus  admonitions (alerts) for: Note, Info, Tip, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
+:::note
+This is the note text.
+:::
+
+# Use GitHub flavored markdown admonitions for all other repositories in the contentauth org
+
+For documents in all other repositories in the contentauth org, use GitHub flavored markdown admonitions (alerts) for: Note, Tip, Important, and Warning.  Use this format instead of just putting "Note," "Warning," and so on, inline in text.  For example:
+> [!NOTE]
+> This is the note text.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "sync:skills": "node scripts/sync-skills.js",
+    "prebuild": "npm run sync:skills",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/scripts/sync-skills.js
+++ b/scripts/sync-skills.js
@@ -1,0 +1,47 @@
+/**
+ * Copies each SKILL.md from .cursor/skills/<name>/ (canonical) to
+ * .claude/skills/<name>/ so Cursor and Claude Code stay aligned.
+ */
+const fs = require('fs/promises');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const cursorSkillsDir = path.join(root, '.cursor', 'skills');
+
+async function sync() {
+  let entries;
+  try {
+    entries = await fs.readdir(cursorSkillsDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return;
+    }
+    throw err;
+  }
+
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const name = ent.name;
+    const src = path.join(cursorSkillsDir, name, 'SKILL.md');
+    try {
+      await fs.access(src);
+    } catch {
+      continue;
+    }
+    const destDir = path.join(root, '.claude', 'skills', name);
+    await fs.mkdir(destDir, { recursive: true });
+    const dest = path.join(destDir, 'SKILL.md');
+    await fs.copyFile(src, dest);
+    console.log(
+      `sync-skills: ${path.relative(root, src)} -> ${path.relative(
+        root,
+        dest,
+      )}`,
+    );
+  }
+}
+
+sync().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a shared **edit-doc** agent skill for this repo and keeps **Cursor** and **Claude** copies in sync with the site build.

## Changes

- **Canonical skill:** `.cursor/skills/edit-doc/SKILL.md` — editorial/style rules for technical docs (glossary, headings, capitalization, Docusaurus vs GitHub admonitions, etc.).
- **Mirrored copy:** `.claude/skills/edit-doc/SKILL.md` — same content for Claude Code–style tooling.
- **Build integration:** `scripts/sync-skills.js` copies every `.cursor/skills/<name>/SKILL.md` into `.claude/skills/<name>/`. A **`prebuild`** script runs `sync:skills` so **`npm run build`** refreshes the `.claude` tree before Docusaurus builds (CI included).
