### PR TITLE
Add deprecation policy

### DIFF
--- a/remote-docs.json
+++ b/remote-docs.json
@@ -172,6 +172,19 @@
       }
     },
 
+    { "_comment": "Working with the SDK" },
+    {
+      "repo": "contentauth/c2pa-rs",
+      "path": "docs/deprecation-policy.md",
+      "dest": "docs/rust-sdk/deprecation-policy.md",
+      "branch": "doc/deprecation-policy",
+      "sidebar": {
+        "category": "tasks",
+        "label": "Deprecation policy",
+        "order": 10
+      }
+    },
+
     { "_comment": "Python library" },
     {
       "repo": "contentauth/c2pa-python",

--- a/remote-docs.json
+++ b/remote-docs.json
@@ -177,7 +177,6 @@
       "repo": "contentauth/c2pa-rs",
       "path": "docs/deprecation-policy.md",
       "dest": "docs/rust-sdk/deprecation-policy.md",
-      "branch": "doc/deprecation-policy",
       "sidebar": {
         "category": "tasks",
         "label": "Deprecation policy",

--- a/sidebars.js
+++ b/sidebars.js
@@ -135,6 +135,7 @@ const sidebars = {
           id: 'tasks/build',
           label: 'Adding and signing a manifest',
         },
+        ...getRemoteSidebarItems('tasks'),
       ],
     },
     {


### PR DESCRIPTION
When https://github.com/contentauth/c2pa-rs/pull/2148 lands, remove this line from `remote-docs.json` then merge.

```
      "branch": "doc/deprecation-policy",
```
