### PR TITLE
Changes for the move of c2pa-node-v2 into c2pa-js repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This table summarizes the content that this script fetches from other repos.
 | `c2pa-cpp` | [c2pa-cpp](https://github.com/contentauth/c2pa-cpp) | C++ library docs. |
 | `c2pa-ios` | [c2pa-ios](https://github.com/contentauth/c2pa-ios) | Mobile iOS library docs. |
 | `c2pa-android` | [c2pa-android](https://github.com/contentauth/c2pa-android) | Android library docs. | 
-| `c2pa-node-v2` | [c2pa-node](https://github.com/contentauth/c2pa-node-v2) | Node library docs. |
+| `c2pa-node-v2` | [c2pa-node](https://github.com/contentauth/c2pa-js/tree/main/packages/c2pa-node) | Node library docs (packages/c2pa-node in c2pa-js monorepo). |
 | `c2pa-node-example`  | [c2pa-node-example](https://github.com/contentauth/c2pa-node-example) | Node example app.|
 | `c2pa-python` | [c2pa-python](https://github.com/contentauth/c2pa-python) | Python library docs. |
 | `c2pa-python example` | [c2pa-python-example](https://github.com/contentauth/c2pa-python-example) | Python example app. |

--- a/docs/community.md
+++ b/docs/community.md
@@ -13,7 +13,7 @@ All the open-source CAI code is hosted in GitHub in the [CAI GitHub organization
 - **CLI tool**: [c2patool](https://github.com/contentauth/c2patool)
 - **JavaScript library**: [c2pa-web](https://github.com/contentauth/c2pa-web)
 - **Python library**: [c2pa-python](https://github.com/contentauth/c2pa-python)
-- **Node.js library**: [c2pa-node-v2](https://github.com/contentauth/c2pa-node-v2)
+- **Node.js library**: [c2pa-node](https://github.com/contentauth/c2pa-js/tree/main/packages/c2pa-node)
 - **C++ library**: [c2pa-cpp](https://github.com/contentauth/c2pa-cpp)
 
 If you think you've found a bug or want to request a feature, please open an issue in the appropriate repository.

--- a/docs/js-landing.mdx
+++ b/docs/js-landing.mdx
@@ -12,7 +12,7 @@ The [c2pa-js](c2pa-js/README.md) repository is a monorepo containing the followi
 
 - [**c2pa-web**](c2pa-js/packages/c2pa-web/README.md): Library for C2PA metadata in the browser. Import and use this package in browser client JavaScript code.
 - [**c2pa-wasm**](c2pa-js/packages/c2pa-wasm/README.md): WebAssembly bindings for c2pa-rs, built with wasm-bindgen. They power c2pa-web; most applications should use c2pa-web instead of calling the bindings directly.
-- [**c2pa-types**](c2pa-js/packages/c2pa-types/README.md): TypeScript types generated from c2pa-rs structs for use by c2pa-web and c2pa-node-v2.
+- [**c2pa-types**](c2pa-js/packages/c2pa-types/README.md): TypeScript types generated from c2pa-rs structs for use by c2pa-web and c2pa-node.
 
 
 For video walkthroughs on using the JavaScript SDK, see the following lessons from the Content Credentials Foundations course:

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -1,13 +1,13 @@
 ---
 id: node-landing
 title: Node.js library
-custom_edit_path: c2pa-node-v2/edit/main/README.md
+custom_edit_path: c2pa-js/edit/main/packages/c2pa-node/README.md
 ---
 
 import Readme from './c2pa-node-v2/readme.md';
 
 :::note
-The old [c2pa-node library](c2pa-node/readme.md) is still available, but it's deprecated and will no longer be updated or supported.  Move to the new `c2pa-node-v2` library as soon as possible!
+The old [c2pa-node library](c2pa-node/readme.md) is deprecated and will no longer be updated or supported.
 :::
 
 <Readme components={{ h1: () => null }} />

--- a/docs/tasks/node/_node-archives.mdx
+++ b/docs/tasks/node/_node-archives.mdx
@@ -111,4 +111,4 @@ const ingredients = active?.ingredients ?? [];
 
 ### Ingredient archives
 
-To build a reusable ingredient catalog, add ingredients (stable `instance_id` values help later lookup), then call `toArchive`. Consumers read the archive with `Reader` and merge selected ingredients into a signing `Builder`, transferring thumbnails and `manifest_data` URIs with `resourceToAsset` / `addResource` as in the [@contentauth/c2pa-node README](https://github.com/contentauth/c2pa-node-v2#adding-ingredients-from-archives-c2pa-files).
+To build a reusable ingredient catalog, add ingredients (stable `instance_id` values help later lookup), then call `toArchive`. Consumers read the archive with `Reader` and merge selected ingredients into a signing `Builder`, transferring thumbnails and `manifest_data` URIs with `resourceToAsset` / `addResource` as in the [@contentauth/c2pa-node README](https://github.com/contentauth/c2pa-js/tree/main/packages/c2pa-node#adding-ingredients-from-archives-c2pa-files).

--- a/docs/tasks/node/_node-build.md
+++ b/docs/tasks/node/_node-build.md
@@ -103,4 +103,4 @@ await builder.signAsync(
 
 Replace `customSign` with your implementation that returns the detached signature bytes for the C2PA claim.
 
-For identity assertions (CAWG), see `IdentityAssertionBuilder` and `IdentityAssertionSigner` in the [c2pa-node-v2 README](https://github.com/contentauth/c2pa-node-v2#identity-assertion-components).
+For identity assertions (CAWG), see `IdentityAssertionBuilder` and `IdentityAssertionSigner` in the [c2pa-node README](https://github.com/contentauth/c2pa-js/tree/main/packages/c2pa-node#identity-assertion-components).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,7 +27,11 @@ const externalRepos = {
   'c2pa-android': { repo: 'c2pa-android', path: '', org: 'contentauth' },
   'c2pa-js': { repo: 'c2pa-js', path: '', org: 'contentauth' },
 
-  'c2pa-node-v2': { repo: 'c2pa-node', path: '', org: 'contentauth' },
+  'c2pa-node': {
+    repo: 'c2pa-js',
+    path: 'packages/c2pa-node/',
+    org: 'contentauth',
+  },
   'c2pa-python': { repo: 'c2pa-python', path: '', org: 'contentauth' },
   'c2pa-python-example': {
     repo: 'c2pa-python-example',

--- a/remote-docs.json
+++ b/remote-docs.json
@@ -417,10 +417,11 @@
       "sidebar": { "category": "c2pa-js", "label": "c2pa-wasm", "order": 4 }
     },
 
-    { "_comment": "Node.js library" },
+    { "_comment": "Node.js library (packages/c2pa-node in c2pa-js monorepo)" },
     {
-      "repo": "contentauth/c2pa-node-v2",
-      "path": "README.md",
+      "repo": "contentauth/c2pa-js",
+      "branch": "feat/migrate-c2pa-node",
+      "path": "packages/c2pa-node/README.md",
       "dest": "docs/c2pa-node-v2/readme.md"
     },
     {
@@ -428,7 +429,7 @@
       "path": "docs/supported-formats.md",
       "dest": "docs/c2pa-node-v2/supported-formats.md",
       "sidebar": {
-        "category": "c2pa-node-v2",
+        "category": "c2pa-node",
         "label": "Supported media formats",
         "order": 1
       }

--- a/remote-docs.json
+++ b/remote-docs.json
@@ -420,7 +420,6 @@
     { "_comment": "Node.js library (packages/c2pa-node in c2pa-js monorepo)" },
     {
       "repo": "contentauth/c2pa-js",
-      "branch": "feat/migrate-c2pa-node",
       "path": "packages/c2pa-node/README.md",
       "dest": "docs/c2pa-node-v2/readme.md"
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -290,16 +290,16 @@ const sidebars = {
       link: { type: 'doc', id: 'node-landing' },
       collapsed: true,
       items: [
-        ...getRemoteSidebarItems('c2pa-node-v2'),
+        ...getRemoteSidebarItems('c2pa-node'),
         {
           type: 'link',
           label: 'API documentation',
-          href: 'https://contentauth.github.io/c2pa-node-v2/',
+          href: 'https://contentauth.github.io/c2pa-js/',
         },
         {
           type: 'link',
           label: 'GitHub',
-          href: 'https://github.com/contentauth/c2pa-node-v2/tree/main',
+          href: 'https://github.com/contentauth/c2pa-js/tree/main/packages/c2pa-node',
         },
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -275,7 +275,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'API documentation',
-          href: 'https://contentauth.github.io/c2pa-js/',
+          href: 'https://contentauth.github.io/c2pa-js/modules/_contentauth_c2pa-web.html',
         },
         {
           type: 'link',
@@ -294,7 +294,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'API documentation',
-          href: 'https://contentauth.github.io/c2pa-js/',
+          href: 'https://contentauth.github.io/c2pa-js/modules/_contentauth_c2pa-node.html',
         },
         {
           type: 'link',


### PR DESCRIPTION
Doc changes to align with https://github.com/contentauth/c2pa-js/pull/125

