### PR TITLE
Add ChronoVerify MCP server to Related projects

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -39,6 +39,7 @@ These related projects may be of interest, but the CAI team doesn't maintain or 
 - [**DASH video player**](https://github.com/contentauth/dash.js/tree/c2pa-dash):  DASH video player that displays Content Credentials in browsers for supported media types. This repo/branch is a work-in-progress forked from [dash.js](https://github.com/Dash-Industry-Forum/dash.js), the canonical reference JavaScript implementation for the playback of MPEG DASH. 
 - [**TrustMark**](https://github.com/adobe/trustmark): Open-source Python implementation of watermarking for encoding, decoding and removing image watermarks. You can use TrustMark as part of providing [durable content credentials](durable-cr/index.md).
 - [**C2PA Security Testing Tool**](https://github.com/contentauth/c2pa-attacks): A CLI tool derived from [c2patool](https://github.com/contentauth/c2patool) that performs security testing on a Content Credentials application.  This tool is intended for use by software security professionals.
+- [**ChronoVerify MCP server**](https://github.com/beeswaxpat/chronoverify-mcp): Model Context Protocol (MCP) server for [ChronoVerify](https://chronoverify.com), a C2PA Conformant Validator listed on the [Conforming Products List](https://c2pa.org/conformance/). Lets AI agents and applications validate C2PA Content Credentials in images against the official trust lists, alongside EXIF/XMP metadata and pixel-forensics checks.
 
 ## Browser extension
 


### PR DESCRIPTION
Adds ChronoVerify's MCP server to the Related projects list on the Community resources page, following the existing entry format (community-maintained, not supported by the CAI team). ChronoVerify is a validator product on the C2PA Conforming Products List (record 019f8a20-6452-7a43-b11b-59d0b0e4a84a) and validates Content Credentials against the official trust lists; the MCP server lets AI agents and applications call it. Disclosure: I am the founder and maintainer.