### PR TITLE
Consolidate and update pnpm dependency overrides for security patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,35 @@
   },
   "pnpm": {
     "overrides": {
-      "webpackbar": "^7.0.0"
+      "webpackbar": "^7.0.0",
+      "webpack": ">=5.104.1",
+      "serialize-javascript": ">=7.0.5",
+      "svgo": ">=3.3.4",
+      "path-to-regexp": ">=0.1.13",
+      "brace-expansion": ">=1.1.18",
+      "picomatch": ">=2.3.2",
+      "yaml": ">=1.10.3",
+      "dompurify": ">=3.4.13",
+      "lodash-es": ">=4.18.0",
+      "lodash": ">=4.18.0",
+      "follow-redirects": ">=1.16.0",
+      "postcss": ">=8.5.23",
+      "fast-uri": ">=3.1.5",
+      "webpack-dev-server": ">=5.2.6",
+      "ws": ">=8.21.0",
+      "uuid": ">=11.1.1",
+      "qs": ">=6.15.2",
+      "mermaid": ">=11.16.1",
+      "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+      "shell-quote": ">=1.9.0",
+      "joi": ">=17.13.4",
+      "launch-editor": ">=2.14.1",
+      "http-proxy-middleware": ">=2.0.10",
+      "js-yaml": ">=4.3.1",
+      "websocket-driver": ">=0.7.5",
+      "@babel/core": ">=7.29.6 <8.0.0",
+      "body-parser": ">=1.20.6",
+      "nanoid": ">=3.3.17"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,34 @@ settings:
 
 overrides:
   webpackbar: ^7.0.0
+  webpack: '>=5.104.1'
+  serialize-javascript: '>=7.0.5'
+  svgo: '>=3.3.4'
+  path-to-regexp: '>=0.1.13'
+  brace-expansion: '>=1.1.18'
+  picomatch: '>=2.3.2'
+  yaml: '>=1.10.3'
+  dompurify: '>=3.4.13'
+  lodash-es: '>=4.18.0'
+  lodash: '>=4.18.0'
+  follow-redirects: '>=1.16.0'
+  postcss: '>=8.5.23'
+  fast-uri: '>=3.1.5'
+  webpack-dev-server: '>=5.2.6'
+  ws: '>=8.21.0'
+  uuid: '>=11.1.1'
+  qs: '>=6.15.2'
+  mermaid: '>=11.16.1'
+  '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
+  shell-quote: '>=1.9.0'
+  joi: '>=17.13.4'
+  launch-editor: '>=2.14.1'
+  http-proxy-middleware: '>=2.0.10'
+  js-yaml: '>=4.3.1'
+  websocket-driver: '>=0.7.5'
+  '@babel/core': '>=7.29.6 <8.0.0'
+  body-parser: '>=1.20.6'
+  nanoid: '>=3.3.17'
 
 dependencies:
   '@contentauth/react':
@@ -34,7 +62,7 @@ dependencies:
     version: 1.11.0
   c2pa-wc:
     specifier: ^0.14.17
-    version: 0.14.17
+    version: 0.14.17(postcss@8.5.26)
   clsx:
     specifier: ^1.1.1
     version: 1.2.1
@@ -85,7 +113,7 @@ packages:
       }
     engines: { node: '>=11' }
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 5.2.3
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -381,6 +409,29 @@ packages:
       picocolors: 1.1.1
     dev: false
 
+  /@babel/code-frame@7.29.7:
+    resolution:
+      {
+        integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
+      }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+    dev: false
+
+  /@babel/code-frame@8.0.0:
+    resolution:
+      {
+        integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+    dev: false
+
   /@babel/compat-data@7.29.0:
     resolution:
       {
@@ -389,22 +440,30 @@ packages:
     engines: { node: '>=6.9.0' }
     dev: false
 
-  /@babel/core@7.29.0:
+  /@babel/compat-data@7.29.7:
     resolution:
       {
-        integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
+        integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
+      }
+    engines: { node: '>=6.9.0' }
+    dev: false
+
+  /@babel/core@7.29.7:
+    resolution:
+      {
+        integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
       }
     engines: { node: '>=6.9.0' }
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@9.4.0)
@@ -429,6 +488,35 @@ packages:
       jsesc: 3.1.0
     dev: false
 
+  /@babel/generator@7.29.8:
+    resolution:
+      {
+        integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==,
+      }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+    dev: false
+
+  /@babel/generator@8.0.0:
+    resolution:
+      {
+        integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+    dev: false
+
   /@babel/helper-annotate-as-pure@7.27.3:
     resolution:
       {
@@ -448,25 +536,39 @@ packages:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: false
 
-  /@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0):
+  /@babel/helper-compilation-targets@7.29.7:
+    resolution:
+      {
+        integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
+      }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.7
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: false
+
+  /@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
       semver: 6.3.1
@@ -474,30 +576,30 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0):
+  /@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
     dev: false
 
-  /@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.0):
+  /@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==,
       }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@9.4.0)
@@ -513,6 +615,22 @@ packages:
         integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
       }
     engines: { node: '>=6.9.0' }
+    dev: false
+
+  /@babel/helper-globals@7.29.7:
+    resolution:
+      {
+        integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
+      }
+    engines: { node: '>=6.9.0' }
+    dev: false
+
+  /@babel/helper-globals@8.0.0:
+    resolution:
+      {
+        integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
     dev: false
 
   /@babel/helper-member-expression-to-functions@7.28.5:
@@ -541,21 +659,77 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0):
+  /@babel/helper-module-imports@7.29.7:
+    resolution:
+      {
+        integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
+      }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-module-imports@8.0.0:
+    resolution:
+      {
+        integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+    dev: false
+
+  /@babel/helper-module-transforms@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7):
+    resolution:
+      {
+        integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
+      }
+    engines: { node: '>=6.9.0' }
+    peerDependencies:
+      '@babel/core': '>=7.29.6 <8.0.0'
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-module-transforms@8.0.1(@babel/core@7.29.7):
+    resolution:
+      {
+        integrity: sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    peerDependencies:
+      '@babel/core': '>=7.29.6 <8.0.0'
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+      '@babel/traverse': 8.0.4
     dev: false
 
   /@babel/helper-optimise-call-expression@7.27.1:
@@ -576,16 +750,28 @@ packages:
     engines: { node: '>=6.9.0' }
     dev: false
 
-  /@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0):
+  /@babel/helper-plugin-utils@8.0.1(@babel/core@7.29.7):
+    resolution:
+      {
+        integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    peerDependencies:
+      '@babel/core': '>=7.29.6 <8.0.0'
+    dependencies:
+      '@babel/core': 7.29.7
+    dev: false
+
+  /@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
       '@babel/traverse': 7.29.0
@@ -593,16 +779,16 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0):
+  /@babel/helper-replace-supers@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.29.0
@@ -631,6 +817,22 @@ packages:
     engines: { node: '>=6.9.0' }
     dev: false
 
+  /@babel/helper-string-parser@7.29.7:
+    resolution:
+      {
+        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
+      }
+    engines: { node: '>=6.9.0' }
+    dev: false
+
+  /@babel/helper-string-parser@8.0.0:
+    resolution:
+      {
+        integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dev: false
+
   /@babel/helper-validator-identifier@7.28.5:
     resolution:
       {
@@ -639,10 +841,34 @@ packages:
     engines: { node: '>=6.9.0' }
     dev: false
 
+  /@babel/helper-validator-identifier@7.29.7:
+    resolution:
+      {
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
+      }
+    engines: { node: '>=6.9.0' }
+    dev: false
+
+  /@babel/helper-validator-identifier@8.0.4:
+    resolution:
+      {
+        integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dev: false
+
   /@babel/helper-validator-option@7.27.1:
     resolution:
       {
         integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+      }
+    engines: { node: '>=6.9.0' }
+    dev: false
+
+  /@babel/helper-validator-option@7.29.7:
+    resolution:
+      {
+        integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
       }
     engines: { node: '>=6.9.0' }
     dev: false
@@ -661,15 +887,15 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helpers@7.28.6:
+  /@babel/helpers@7.29.7:
     resolution:
       {
-        integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==,
+        integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
       }
     engines: { node: '>=6.9.0' }
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
     dev: false
 
   /@babel/parser@7.29.0:
@@ -683,448 +909,470 @@ packages:
       '@babel/types': 7.29.0
     dev: false
 
-  /@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0):
+  /@babel/parser@7.29.8:
+    resolution:
+      {
+        integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==,
+      }
+    engines: { node: '>=6.0.0' }
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.29.8
+    dev: false
+
+  /@babel/parser@8.0.4:
+    resolution:
+      {
+        integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    hasBin: true
+    dependencies:
+      '@babel/types': 8.0.4
+    dev: false
+
+  /@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.13.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==,
       }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0):
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0):
+  /@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.12.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0):
+  /@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0):
+  /@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
@@ -1132,709 +1380,706 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0):
+  /@babel/plugin-transform-modules-systemjs@8.0.1(@babel/core@7.29.7):
     resolution:
       {
-        integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==,
+        integrity: sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==,
       }
-    engines: { node: '>=6.9.0' }
+    engines: { node: ^22.18.0 || >=24.11.0 }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-validator-identifier': 8.0.4
     dev: false
 
-  /@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0):
+  /@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-edoidOjl/ZxvYo4lSBOQGDSyToYVkTAwyVoa2tkuYTSmjrB1+uAedoL5iROVLXkxH+vRgA7uP4tMg2pUJpZ3Ug==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0):
+  /@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0):
+  /@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0):
+  /@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0):
+  /@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0):
+  /@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     dev: false
 
-  /@babel/preset-env@7.29.0(@babel/core@7.29.0):
+  /@babel/preset-env@7.29.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-systemjs': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.7)
       core-js-compat: 3.48.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0):
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==,
       }
     peerDependencies:
-      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
     dev: false
 
-  /@babel/preset-react@7.28.5(@babel/core@7.29.0):
+  /@babel/preset-react@7.28.5(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/preset-typescript@7.28.5(@babel/core@7.29.0):
+  /@babel/preset-typescript@7.28.5(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==,
       }
     engines: { node: '>=6.9.0' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1867,6 +2112,30 @@ packages:
       '@babel/types': 7.29.0
     dev: false
 
+  /@babel/template@7.29.7:
+    resolution:
+      {
+        integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
+      }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+    dev: false
+
+  /@babel/template@8.0.0:
+    resolution:
+      {
+        integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+    dev: false
+
   /@babel/traverse@7.29.0:
     resolution:
       {
@@ -1885,6 +2154,40 @@ packages:
       - supports-color
     dev: false
 
+  /@babel/traverse@7.29.8:
+    resolution:
+      {
+        integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==,
+      }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/traverse@8.0.4:
+    resolution:
+      {
+        integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+      obug: 2.1.4
+    dev: false
+
   /@babel/types@7.29.0:
     resolution:
       {
@@ -1896,6 +2199,28 @@ packages:
       '@babel/helper-validator-identifier': 7.28.5
     dev: false
 
+  /@babel/types@7.29.8:
+    resolution:
+      {
+        integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==,
+      }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+    dev: false
+
+  /@babel/types@8.0.4:
+    resolution:
+      {
+        integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+    dev: false
+
   /@braintree/sanitize-url@7.1.2:
     resolution:
       {
@@ -1903,45 +2228,10 @@ packages:
       }
     dev: false
 
-  /@chevrotain/cst-dts-gen@11.1.1:
+  /@chevrotain/types@11.1.2:
     resolution:
       {
-        integrity: sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw==,
-      }
-    dependencies:
-      '@chevrotain/gast': 11.1.1
-      '@chevrotain/types': 11.1.1
-      lodash-es: 4.17.23
-    dev: false
-
-  /@chevrotain/gast@11.1.1:
-    resolution:
-      {
-        integrity: sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg==,
-      }
-    dependencies:
-      '@chevrotain/types': 11.1.1
-      lodash-es: 4.17.23
-    dev: false
-
-  /@chevrotain/regexp-to-ast@11.1.1:
-    resolution:
-      {
-        integrity: sha512-ctRw1OKSXkOrR8VTvOxrQ5USEc4sNrfwXHa1NuTcR7wre4YbjPcKw+82C2uylg/TEwFRgwLmbhlln4qkmDyteg==,
-      }
-    dev: false
-
-  /@chevrotain/types@11.1.1:
-    resolution:
-      {
-        integrity: sha512-wb2ToxG8LkgPYnKe9FH8oGn3TMCBdnwiuNC5l5y+CtlaVRbCytU0kbVsk6CGrqTL4ZN4ksJa0TXOYbxpbthtqw==,
-      }
-    dev: false
-
-  /@chevrotain/utils@11.1.1:
-    resolution:
-      {
-        integrity: sha512-71eTYMzYXYSFPrbg/ZwftSaSDld7UYlS8OQa3lNnn9jzNtpFbaReRRyghzqS7rI3CDaorqpPJJcXGHK+FE1TVQ==,
+        integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==,
       }
     dev: false
 
@@ -1974,9 +2264,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       c2pa: 0.30.17
-      c2pa-wc: 0.14.17
+      c2pa-wc: 0.14.17(postcss@8.5.26)
       classnames: 2.3.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
@@ -2075,591 +2365,591 @@ packages:
       '@csstools/css-tokenizer': 3.0.4
     dev: false
 
-  /@csstools/postcss-alpha-function@1.0.1(postcss@8.5.6):
+  /@csstools/postcss-alpha-function@1.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-isfLLwksH3yHkFXfCI2Gcaqg7wGGHZZwunoJzEZk0yKYIokgre6hYVFibKL3SYAoR1kBXova8LB+JoO5vZzi9w==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.6):
+  /@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-nWBE08nhO8uWl6kSAeCx4im7QfVko3zLrtgWZY4/bP87zrSPpSyN/3W3TDqz1jJuH+kbKOHXg5rJnK+ZVYcFFg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.6):
+  /@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-E5qusdzhlmO1TztYzDIi8XPdPoYOjoTY6HBYBCYSj+Gn4gQRBlvjgPQXzfzuPQqt8EhkC/SzPKObg4Mbn8/xMg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-color-function@4.0.12(postcss@8.5.6):
+  /@csstools/postcss-color-function@4.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-yx3cljQKRaSBc2hfh8rMZFZzChaFgwmO2JfFgFr1vMcF3C/uyy5I4RFIBOIWGq1D+XbKCG789CGkG6zzkLpagA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-color-mix-function@3.0.12(postcss@8.5.6):
+  /@csstools/postcss-color-mix-function@3.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-4STERZfCP5Jcs13P1U5pTvI9SkgLgfMUMhdXW8IlJWkzOOOqhZIjcNhWtNJZes2nkBDsIKJ0CJtFtuaZ00moag==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-color-mix-variadic-function-arguments@1.0.2(postcss@8.5.6):
+  /@csstools/postcss-color-mix-variadic-function-arguments@1.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-rM67Gp9lRAkTo+X31DUqMEq+iK+EFqsidfecmhrteErxJZb6tUoJBVQca1Vn1GpDql1s1rD1pKcuYzMsg7Z1KQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-content-alt-text@2.0.8(postcss@8.5.6):
+  /@csstools/postcss-content-alt-text@2.0.8(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-9SfEW9QCxEpTlNMnpSqFaHyzsiRpZ5J5+KqCu1u5/eEJAWsMhzT40qf0FIbeeglEvrGRMdDzAxMIz3wqoGSb+Q==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-contrast-color-function@2.0.12(postcss@8.5.6):
+  /@csstools/postcss-contrast-color-function@2.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-YbwWckjK3qwKjeYz/CijgcS7WDUCtKTd8ShLztm3/i5dhh4NaqzsbYnhm4bjrpFpnLZ31jVcbK8YL77z3GBPzA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.6):
+  /@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-abg2W/PI3HXwS/CZshSa79kNWNZHdJPMBXeZNyPQFbbj8sKO3jXxOt/wF7juJVjyDTc6JrvaUZYFcSBZBhaxjw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.6):
+  /@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-usBzw9aCRDvchpok6C+4TXC57btc4bJtmKQWOHQxOVKen1ZfVqBUuCZ/wuqdX5GHsD0NRSr9XTP+5ID1ZZQBXw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.6):
+  /@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-fCpCUgZNE2piVJKC76zFsgVW1apF6dpYsqGyH8SIeCcM4pTEsRTWTLCaJIMKFEundsCKwY1rwfhtrio04RJ4Dw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-gradients-interpolation-method@5.0.12(postcss@8.5.6):
+  /@csstools/postcss-gradients-interpolation-method@5.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-jugzjwkUY0wtNrZlFeyXzimUL3hN4xMvoPnIXxoZqxDvjZRiSh+itgHcVUWzJ2VwD/VAMEgCLvtaJHX+4Vj3Ow==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-hwb-function@4.0.12(postcss@8.5.6):
+  /@csstools/postcss-hwb-function@4.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-mL/+88Z53KrE4JdePYFJAQWFrcADEqsLprExCM04GDNgHIztwFzj0Mbhd/yxMBngq0NIlz58VVxjt5abNs1VhA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-ic-unit@4.0.4(postcss@8.5.6):
+  /@csstools/postcss-ic-unit@4.0.4(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-yQ4VmossuOAql65sCPppVO1yfb7hDscf4GseF0VCA/DTDaBc0Wtf8MTqVPfjGYlT5+2buokG0Gp7y0atYZpwjg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /@csstools/postcss-initial@2.0.1(postcss@8.5.6):
+  /@csstools/postcss-initial@2.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-L1wLVMSAZ4wovznquK0xmC7QSctzO4D0Is590bxpGqhqjboLXYA16dWZpfwImkdOgACdQ9PqXsuRroW6qPlEsg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.6):
+  /@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /@csstools/postcss-light-dark-function@2.0.11(postcss@8.5.6):
+  /@csstools/postcss-light-dark-function@2.0.11(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-fNJcKXJdPM3Lyrbmgw2OBbaioU7yuKZtiXClf4sGdQttitijYlZMD5K7HrC/eF83VRWRrYq6OZ0Lx92leV2LFA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.6):
+  /@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-SEmaHMszwakI2rqKRJgE+8rpotFfne1ZS6bZqBoQIicFyV+xT1UF42eORPxJkVJVrH9C0ctUgwMSn3BLOIZldQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.6):
+  /@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-spzR1MInxPuXKEX2csMamshR4LRaSZ3UXVaRGjeQxl70ySxOhMpP2252RAFsg8QyyBXBzuVOOdx1+bVO5bPIzA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.6):
+  /@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-e/webMjoGOSYfqLunyzByZj5KKe5oyVg/YSbie99VEaSDE2kimFm0q1f6t/6Jo+VVCQ/jbe2Xy+uX+C4xzWs4w==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-logical-resize@3.0.0(postcss@8.5.6):
+  /@csstools/postcss-logical-resize@3.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-DFbHQOFW/+I+MY4Ycd/QN6Dg4Hcbb50elIJCfnwkRTCX05G11SwViI5BbBlg9iHRl4ytB7pmY5ieAFk3ws7yyg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.6):
+  /@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-q+eHV1haXA4w9xBwZLKjVKAWn3W2CMqmpNpZUk5kRprvSiBEGMgrNH3/sJZ8UA3JgyHaOt3jwT9uFa4wLX4EqQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-media-minmax@2.0.9(postcss@8.5.6):
+  /@csstools/postcss-media-minmax@2.0.9(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-af9Qw3uS3JhYLnCbqtZ9crTvvkR+0Se+bBqSr7ykAnl9yKhk6895z9rf+2F4dClIDJWxgn0iZZ1PSdkhrbs2ig==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.6):
+  /@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-zhAe31xaaXOY2Px8IYfoVTB3wglbJUVigGphFLj6exb7cjZRH9A6adyE22XfFK3P2PzwRk0VDeTJmaxpluyrDg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-nested-calc@4.0.0(postcss@8.5.6):
+  /@csstools/postcss-nested-calc@4.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-jMYDdqrQQxE7k9+KjstC3NbsmC063n1FTPLCgCRS2/qHUbHM0mNy9pIn4QIiQGs9I/Bg98vMqw7mJXBxa0N88A==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.6):
+  /@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /@csstools/postcss-oklab-function@4.0.12(postcss@8.5.6):
+  /@csstools/postcss-oklab-function@4.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-HhlSmnE1NKBhXsTnNGjxvhryKtO7tJd1w42DKOGFD6jSHtYOrsJTQDKPMwvOfrzUAk8t7GcpIfRyM7ssqHpFjg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-position-area-property@1.0.0(postcss@8.5.6):
+  /@csstools/postcss-position-area-property@1.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-fUP6KR8qV2NuUZV3Cw8itx0Ep90aRjAZxAEzC3vrl6yjFv+pFsQbR18UuQctEKmA72K9O27CoYiKEgXxkqjg8Q==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.6):
+  /@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-uPiiXf7IEKtUQXsxu6uWtOlRMXd2QWWy5fhxHDnPdXKCQckPP3E34ZgDoZ62r2iT+UOgWsSbM4NvHE5m3mAEdw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /@csstools/postcss-property-rule-prelude-list@1.0.0(postcss@8.5.6):
+  /@csstools/postcss-property-rule-prelude-list@1.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-IxuQjUXq19fobgmSSvUDO7fVwijDJaZMvWQugxfEUxmjBeDCVaDuMpsZ31MsTm5xbnhA+ElDi0+rQ7sQQGisFA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-random-function@2.0.1(postcss@8.5.6):
+  /@csstools/postcss-random-function@2.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-q+FQaNiRBhnoSNo+GzqGOIBKoHQ43lYz0ICrV+UudfWnEF6ksS6DsBIJSISKQT2Bvu3g4k6r7t0zYrk5pDlo8w==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-relative-color-syntax@3.0.12(postcss@8.5.6):
+  /@csstools/postcss-relative-color-syntax@3.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-0RLIeONxu/mtxRtf3o41Lq2ghLimw0w9ByLWnnEVuy89exmEEq8bynveBxNW3nyHqLAFEeNtVEmC1QK9MZ8Huw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.6):
+  /@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-IMi9FwtH6LMNuLea1bjVMQAsUhFxJnyLSgOp/cpv5hrzWmrUYU5fm0EguNDIIOHUqzXode8F/1qkC/tEo/qN8Q==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /@csstools/postcss-sign-functions@1.1.4(postcss@8.5.6):
+  /@csstools/postcss-sign-functions@1.1.4(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-P97h1XqRPcfcJndFdG95Gv/6ZzxUBBISem0IDqPZ7WMvc/wlO+yU0c5D/OCpZ5TJoTt63Ok3knGk64N+o6L2Pg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.6):
+  /@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-h9btycWrsex4dNLeQfyU3y3w40LMQooJWFMm/SK9lrKguHDcFl4VMkncKKoXi2z5rM9YGWbUQABI8BT2UydIcA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-syntax-descriptor-syntax-production@1.0.1(postcss@8.5.6):
+  /@csstools/postcss-syntax-descriptor-syntax-production@1.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-GneqQWefjM//f4hJ/Kbox0C6f2T7+pi4/fqTqOFGTL3EjnvOReTqO1qUQ30CaUjkwjYq9qZ41hzarrAxCc4gow==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-system-ui-font-family@1.0.0(postcss@8.5.6):
+  /@csstools/postcss-system-ui-font-family@1.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-s3xdBvfWYfoPSBsikDXbuorcMG1nN1M6GdU0qBsGfcmNR0A/qhloQZpTxjA3Xsyrk1VJvwb2pOfiOT3at/DuIQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.6):
+  /@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-KSkGgZfx0kQjRIYnpsD7X2Om9BUXX/Kii77VBifQW9Ih929hK0KNjVngHDH0bFB9GmfWcR9vJYJJRvw/NQjkrA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/color-helpers': 5.1.0
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.6):
+  /@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-Hnh5zJUdpNrJqK9v1/E3BbrQhaDTj5YiX7P61TOvUhoDHnUmsNNxcDAgkQ32RrcWx9GVUvfUNPcUkn8R3vIX6A==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /@csstools/postcss-unset-value@4.0.0(postcss@8.5.6):
+  /@csstools/postcss-unset-value@4.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-cBz3tOCI5Fw6NIFEwU3RiwK6mn3nKegjpJuzCndoGq3BZPkUjnsq7uQmIeMNeMbMk7YD2MfKcgCpZwX5jyXqCA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
   /@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.1):
@@ -2686,16 +2976,16 @@ packages:
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /@csstools/utilities@2.0.0(postcss@8.5.6):
+  /@csstools/utilities@2.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
   /@discoveryjs/json-ext@0.5.7:
@@ -2774,13 +3064,13 @@ packages:
       }
     engines: { node: '>=20.0' }
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.1
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.0(@babel/core@7.29.7)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
       '@babel/runtime': 7.28.6
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.2
@@ -2810,25 +3100,25 @@ packages:
       '@docusaurus/faster':
         optional: true
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@docusaurus/babel': 3.10.2(react-dom@18.3.1)(react@18.3.1)
       '@docusaurus/cssnano-preset': 3.10.2
       '@docusaurus/logger': 3.10.2
       '@docusaurus/types': 3.10.2(react-dom@18.3.1)(react@18.3.1)
       '@docusaurus/utils': 3.10.2(react-dom@18.3.1)(react@18.3.1)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.105.3)
+      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.105.3)
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.105.3)
       css-loader: 6.11.0(webpack@5.105.3)
       css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.105.3)
-      cssnano: 6.1.2(postcss@8.5.6)
+      cssnano: 6.1.2(postcss@8.5.26)
       file-loader: 6.2.0(webpack@5.105.3)
       html-minifier-terser: 7.2.0
       mini-css-extract-plugin: 2.10.0(webpack@5.105.3)
       null-loader: 4.0.1(webpack@5.105.3)
-      postcss: 8.5.6
-      postcss-loader: 7.3.4(postcss@8.5.6)(webpack@5.105.3)
-      postcss-preset-env: 10.6.1(postcss@8.5.6)
+      postcss: 8.5.26
+      postcss-loader: 7.3.4(postcss@8.5.26)(webpack@5.105.3)
+      postcss-preset-env: 10.6.1(postcss@8.5.26)
       terser-webpack-plugin: 5.3.16(webpack@5.105.3)
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.105.3)
@@ -2890,7 +3180,7 @@ packages:
       html-tags: 3.3.1
       html-webpack-plugin: 5.6.6(webpack@5.105.3)
       leven: 3.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       open: 8.4.2
       p-map: 4.0.0
       prompts: 2.4.2
@@ -2909,7 +3199,7 @@ packages:
       update-notifier: 6.0.2
       webpack: 5.105.3
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.105.3)
+      webpack-dev-server: 6.0.0(tslib@2.8.1)(webpack@5.105.3)
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -2918,7 +3208,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -2935,9 +3224,9 @@ packages:
       }
     engines: { node: '>=20.0' }
     dependencies:
-      cssnano-preset-advanced: 6.1.2(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-sort-media-queries: 5.2.0(postcss@8.5.6)
+      cssnano-preset-advanced: 6.1.2(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-sort-media-queries: 5.2.0(postcss@8.5.26)
       tslib: 2.8.1
     dev: false
 
@@ -3046,7 +3335,7 @@ packages:
       combine-promises: 1.2.0
       feed: 4.2.2
       fs-extra: 11.3.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       schema-dts: 1.1.5
@@ -3064,7 +3353,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3096,8 +3384,8 @@ packages:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.3
-      js-yaml: 4.1.1
-      lodash: 4.17.23
+      js-yaml: 5.2.3
+      lodash: 4.18.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       schema-dts: 1.1.5
@@ -3113,7 +3401,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3152,7 +3439,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3183,7 +3469,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - react
@@ -3222,7 +3507,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3257,7 +3541,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3292,7 +3575,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3327,7 +3609,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3367,7 +3648,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3406,7 +3686,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3454,7 +3733,6 @@ packages:
       - '@types/react'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - search-insights
@@ -3504,9 +3782,9 @@ packages:
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
       infima: 0.2.0-alpha.45
-      lodash: 4.17.23
+      lodash: 4.18.1
       nprogress: 0.2.0
-      postcss: 8.5.6
+      postcss: 8.5.26
       prism-react-renderer: 2.4.1(react@18.3.1)
       prismjs: 1.30.0
       react: 18.3.1
@@ -3524,7 +3802,6 @@ packages:
       - '@types/react'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3587,7 +3864,7 @@ packages:
       '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2)(react-dom@18.3.1)(react@18.3.1)
       '@docusaurus/types': 3.10.2(react-dom@18.3.1)(react@18.3.1)
       '@docusaurus/utils-validation': 3.10.2(react-dom@18.3.1)(react@18.3.1)
-      mermaid: 11.12.3
+      mermaid: 11.16.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -3601,7 +3878,6 @@ packages:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -3635,7 +3911,7 @@ packages:
       clsx: 2.1.1
       eta: 2.2.0
       fs-extra: 11.3.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -3651,7 +3927,6 @@ packages:
       - '@types/react'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - search-insights
@@ -3687,7 +3962,7 @@ packages:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.14
       commander: 5.1.0
-      joi: 17.13.3
+      joi: 18.2.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: /@slorber/react-helmet-async@1.3.0(react-dom@18.3.1)(react@18.3.1)
@@ -3732,9 +4007,9 @@ packages:
       '@docusaurus/utils': 3.10.2(react-dom@18.3.1)(react@18.3.1)
       '@docusaurus/utils-common': 3.10.2(react-dom@18.3.1)(react@18.3.1)
       fs-extra: 11.3.3
-      joi: 17.13.3
-      js-yaml: 4.1.1
-      lodash: 4.17.23
+      joi: 18.2.3
+      js-yaml: 5.2.3
+      lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -3764,8 +4039,8 @@ packages:
       github-slugger: 1.5.0
       globby: 11.1.0
       jiti: 1.21.7
-      js-yaml: 4.1.1
-      lodash: 4.17.23
+      js-yaml: 5.2.3
+      lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
       prompts: 2.4.2
@@ -3800,20 +4075,52 @@ packages:
       '@floating-ui/core': 0.7.3
     dev: false
 
-  /@hapi/hoek@9.3.0:
+  /@hapi/address@5.1.1:
     resolution:
       {
-        integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==,
+        integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@hapi/hoek': 11.0.7
+    dev: false
+
+  /@hapi/formula@3.0.2:
+    resolution:
+      {
+        integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==,
       }
     dev: false
 
-  /@hapi/topo@5.1.0:
+  /@hapi/hoek@11.0.7:
     resolution:
       {
-        integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==,
+        integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==,
+      }
+    dev: false
+
+  /@hapi/pinpoint@2.0.1:
+    resolution:
+      {
+        integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==,
+      }
+    dev: false
+
+  /@hapi/tlds@1.1.7:
+    resolution:
+      {
+        integrity: sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==,
+      }
+    engines: { node: '>=14.0.0' }
+    dev: false
+
+  /@hapi/topo@6.0.2:
+    resolution:
+      {
+        integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==,
       }
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 11.0.7
     dev: false
 
   /@iconify/types@2.0.0:
@@ -4286,13 +4593,13 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@mermaid-js/parser@1.0.0:
+  /@mermaid-js/parser@1.2.0:
     resolution:
       {
-        integrity: sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==,
+        integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==,
       }
     dependencies:
-      langium: 4.2.1
+      '@chevrotain/types': 11.1.2
     dev: false
 
   /@noble/hashes@1.4.0:
@@ -4516,29 +4823,6 @@ packages:
       }
     dev: false
 
-  /@sideway/address@4.1.5:
-    resolution:
-      {
-        integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==,
-      }
-    dependencies:
-      '@hapi/hoek': 9.3.0
-    dev: false
-
-  /@sideway/formula@3.0.1:
-    resolution:
-      {
-        integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==,
-      }
-    dev: false
-
-  /@sideway/pinpoint@2.0.0:
-    resolution:
-      {
-        integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==,
-      }
-    dev: false
-
   /@signalwire/docusaurus-plugin-llms-txt@1.2.2(@docusaurus/core@3.10.2):
     resolution:
       {
@@ -4624,6 +4908,13 @@ packages:
       }
     dev: false
 
+  /@standard-schema/spec@1.1.0:
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+    dev: false
+
   /@stoplight/json-ref-resolver@3.1.6:
     resolution:
       {
@@ -4638,7 +4929,7 @@ packages:
       dependency-graph: 0.11.0
       fast-memoize: 2.5.2
       immer: 9.0.21
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.8.1
       urijs: 1.19.11
     dev: false
@@ -4654,7 +4945,7 @@ packages:
       '@stoplight/path': 1.3.2
       '@stoplight/types': 13.20.0
       jsonc-parser: 2.2.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       safe-stable-stringify: 1.1.1
     dev: false
 
@@ -4685,120 +4976,120 @@ packages:
       utility-types: 3.11.0
     dev: false
 
-  /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0):
+  /@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==,
       }
     engines: { node: '>=12' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
     dev: false
 
-  /@svgr/babel-preset@8.1.0(@babel/core@7.29.0):
+  /@svgr/babel-preset@8.1.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==,
       }
     engines: { node: '>=14' }
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
     dev: false
 
   /@svgr/core@8.1.0:
@@ -4808,8 +5099,8 @@ packages:
       }
     engines: { node: '>=14' }
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6
       snake-case: 3.0.4
@@ -4838,8 +5129,8 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
     dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
       '@svgr/core': 8.1.0
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -4859,7 +5150,7 @@ packages:
       '@svgr/core': 8.1.0
       cosmiconfig: 8.3.6
       deepmerge: 4.3.1
-      svgo: 3.3.2
+      svgo: 4.0.2
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -4871,11 +5162,11 @@ packages:
       }
     engines: { node: '>=14' }
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.0(@babel/core@7.29.7)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
       '@svgr/core': 8.1.0
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)
@@ -4892,14 +5183,6 @@ packages:
     engines: { node: '>=14.16' }
     dependencies:
       defer-to-connect: 2.0.1
-    dev: false
-
-  /@trysound/sax@0.2.0:
-    resolution:
-      {
-        integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==,
-      }
-    engines: { node: '>=10.13.0' }
     dev: false
 
   /@types/body-parser@1.19.6:
@@ -4927,7 +5210,7 @@ packages:
         integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==,
       }
     dependencies:
-      '@types/express-serve-static-core': 4.19.8
+      '@types/express-serve-static-core': 5.1.3
       '@types/node': 25.3.2
     dev: false
 
@@ -5262,10 +5545,10 @@ packages:
         integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
-  /@types/express-serve-static-core@4.19.8:
+  /@types/express-serve-static-core@5.1.3:
     resolution:
       {
-        integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==,
+        integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==,
       }
     dependencies:
       '@types/node': 25.3.2
@@ -5274,16 +5557,15 @@ packages:
       '@types/send': 1.2.1
     dev: false
 
-  /@types/express@4.17.25:
+  /@types/express@5.0.6:
     resolution:
       {
-        integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==,
+        integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==,
       }
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 4.19.8
-      '@types/qs': 6.14.0
-      '@types/serve-static': 1.15.10
+      '@types/express-serve-static-core': 5.1.3
+      '@types/serve-static': 2.2.0
     dev: false
 
   /@types/geojson@7946.0.16:
@@ -5330,15 +5612,6 @@ packages:
       }
     dev: false
 
-  /@types/http-proxy@1.17.17:
-    resolution:
-      {
-        integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==,
-      }
-    dependencies:
-      '@types/node': 25.3.2
-    dev: false
-
   /@types/istanbul-lib-coverage@2.0.6:
     resolution:
       {
@@ -5364,6 +5637,13 @@ packages:
       '@types/istanbul-lib-report': 3.0.3
     dev: false
 
+  /@types/jsesc@2.5.1:
+    resolution:
+      {
+        integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==,
+      }
+    dev: false
+
   /@types/json-schema@7.0.15:
     resolution:
       {
@@ -5382,13 +5662,6 @@ packages:
     resolution:
       {
         integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
-      }
-    dev: false
-
-  /@types/mime@1.3.5:
-    resolution:
-      {
-        integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==,
       }
     dev: false
 
@@ -5484,29 +5757,12 @@ packages:
       csstype: 3.2.3
     dev: false
 
-  /@types/retry@0.12.2:
-    resolution:
-      {
-        integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==,
-      }
-    dev: false
-
   /@types/sax@1.2.7:
     resolution:
       {
         integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==,
       }
     dependencies:
-      '@types/node': 25.3.2
-    dev: false
-
-  /@types/send@0.17.6:
-    resolution:
-      {
-        integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==,
-      }
-    dependencies:
-      '@types/mime': 1.3.5
       '@types/node': 25.3.2
     dev: false
 
@@ -5525,26 +5781,16 @@ packages:
         integrity: sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==,
       }
     dependencies:
-      '@types/express': 4.17.25
+      '@types/express': 5.0.6
     dev: false
 
-  /@types/serve-static@1.15.10:
+  /@types/serve-static@2.2.0:
     resolution:
       {
-        integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==,
+        integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==,
       }
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.3.2
-      '@types/send': 0.17.6
-    dev: false
-
-  /@types/sockjs@0.3.36:
-    resolution:
-      {
-        integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==,
-      }
-    dependencies:
       '@types/node': 25.3.2
     dev: false
 
@@ -5604,6 +5850,16 @@ packages:
       {
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
+    dev: false
+
+  /@upsetjs/venn.js@2.0.0:
+    resolution:
+      {
+        integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==,
+      }
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
     dev: false
 
   /@webassemblyjs/ast@1.14.1:
@@ -5765,16 +6021,15 @@ packages:
       negotiator: 0.6.3
     dev: false
 
-  /acorn-import-assertions@1.9.0(acorn@8.16.0):
+  /accepts@2.0.0:
     resolution:
       {
-        integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==,
+        integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==,
       }
-    deprecated: package has been renamed to acorn-import-attributes
-    peerDependencies:
-      acorn: ^8
+    engines: { node: '>= 0.6' }
     dependencies:
-      acorn: 8.16.0
+      mime-types: 3.0.2
+      negotiator: 1.0.0
     dev: false
 
   /acorn-import-phases@1.0.4(acorn@8.16.0):
@@ -5908,7 +6163,7 @@ packages:
       }
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6031,7 +6286,7 @@ packages:
     engines: { node: '>= 8' }
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 4.0.5
     dev: false
 
   /arg@5.0.2:
@@ -6057,13 +6312,6 @@ packages:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
-
-  /array-flatten@1.1.1:
-    resolution:
-      {
-        integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==,
-      }
-    dev: false
 
   /array-union@2.1.0:
     resolution:
@@ -6123,7 +6371,7 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  /autoprefixer@10.4.27(postcss@8.5.6):
+  /autoprefixer@10.4.27(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==,
@@ -6131,13 +6379,13 @@ packages:
     engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001809
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
@@ -6150,17 +6398,17 @@ packages:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  /babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.3):
+  /babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.105.3):
     resolution:
       {
         integrity: sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==,
       }
     engines: { node: '>= 14.15.0' }
     peerDependencies:
-      '@babel/core': ^7.12.0
-      webpack: '>=5'
+      '@babel/core': '>=7.29.6 <8.0.0'
+      webpack: '>=5.104.1'
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
       webpack: 5.105.3
@@ -6175,62 +6423,62 @@ packages:
       object.assign: 4.1.7
     dev: false
 
-  /babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.0):
+  /babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==,
       }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
+  /babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==,
       }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.7)
       core-js-compat: 3.48.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-corejs3@0.14.0(@babel/core@7.29.0):
+  /babel-plugin-polyfill-corejs3@0.14.0(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==,
       }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.7)
       core-js-compat: 3.48.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /babel-plugin-polyfill-regenerator@0.6.6(@babel/core@7.29.0):
+  /babel-plugin-polyfill-regenerator@0.6.6(@babel/core@7.29.7):
     resolution:
       {
         integrity: sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==,
       }
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': '>=7.29.6 <8.0.0'
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6241,11 +6489,12 @@ packages:
         integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
       }
 
-  /balanced-match@1.0.2:
+  /balanced-match@4.0.4:
     resolution:
       {
-        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
       }
+    engines: { node: 18 || 20 || >=22 }
 
   /baseline-browser-mapping@2.11.12:
     resolution:
@@ -6283,25 +6532,22 @@ packages:
     engines: { node: '>=8' }
     dev: false
 
-  /body-parser@1.20.4:
+  /body-parser@2.3.0:
     resolution:
       {
-        integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==,
+        integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==,
       }
-    engines: { node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16 }
+    engines: { node: '>=18' }
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@9.4.0)
       http-errors: 2.0.1
-      iconv-lite: 0.4.24
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.14.2
-      raw-body: 2.5.3
-      type-is: 1.6.18
-      unpipe: 1.0.0
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6357,14 +6603,14 @@ packages:
       wrap-ansi: 8.1.0
     dev: false
 
-  /brace-expansion@1.1.12:
+  /brace-expansion@5.0.9:
     resolution:
       {
-        integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
+        integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==,
       }
+    engines: { node: 20 || >=22 }
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
+      balanced-match: 4.0.4
 
   /braces@3.0.3:
     resolution:
@@ -6444,7 +6690,7 @@ packages:
     engines: { node: '>=6.0.0' }
     dev: false
 
-  /c2pa-wc@0.14.17:
+  /c2pa-wc@0.14.17(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-gQc6vpjPNGS/AkEeFNu1gO7QdCbEg1GewooocLLqPhP3bOIBeprLsxB30wnNSLiam4KO6JWWImh6dJQEBxLiYA==,
@@ -6458,11 +6704,20 @@ packages:
       fast-deep-equal: 3.1.3
       lit: 2.8.0
       lit-html: 2.8.0
-      lodash: 4.17.23
-      webpack: 5.91.0
+      lodash: 4.18.1
+      webpack: 5.109.2(postcss@8.5.26)
     transitivePeerDependencies:
+      - '@minify-html/node'
       - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - supports-color
       - uglify-js
       - webpack-cli
@@ -6478,7 +6733,7 @@ packages:
       '@contentauth/detector': 0.3.7
       '@contentauth/toolkit': 0.13.14
       debug: 4.3.7
-      lodash: 4.17.23
+      lodash: 4.18.1
       make-error: 1.3.6
       p-props: 5.0.0
       traverse: 0.6.11
@@ -6693,32 +6948,6 @@ packages:
       parse5-htmlparser2-tree-adapter: 7.1.0
     dev: false
 
-  /chevrotain-allstar@0.3.1(chevrotain@11.1.1):
-    resolution:
-      {
-        integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==,
-      }
-    peerDependencies:
-      chevrotain: ^11.0.0
-    dependencies:
-      chevrotain: 11.1.1
-      lodash-es: 4.17.23
-    dev: false
-
-  /chevrotain@11.1.1:
-    resolution:
-      {
-        integrity: sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==,
-      }
-    dependencies:
-      '@chevrotain/cst-dts-gen': 11.1.1
-      '@chevrotain/gast': 11.1.1
-      '@chevrotain/regexp-to-ast': 11.1.1
-      '@chevrotain/types': 11.1.1
-      '@chevrotain/utils': 11.1.1
-      lodash-es: 4.17.23
-    dev: false
-
   /chokidar@3.6.0:
     resolution:
       {
@@ -6735,6 +6964,16 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: false
+
+  /chokidar@5.0.0:
+    resolution:
+      {
+        integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
+      }
+    engines: { node: '>= 20.19.0' }
+    dependencies:
+      readdirp: 5.1.1
     dev: false
 
   /chrome-trace-event@1.0.4:
@@ -6916,6 +7155,7 @@ packages:
       {
         integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
       }
+    dev: true
 
   /combine-promises@1.2.0:
     resolution:
@@ -6938,6 +7178,14 @@ packages:
         integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==,
       }
     engines: { node: '>=14' }
+    dev: false
+
+  /commander@11.1.0:
+    resolution:
+      {
+        integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==,
+      }
+    engines: { node: '>=16' }
     dev: false
 
   /commander@2.20.3:
@@ -7013,12 +7261,6 @@ packages:
       - supports-color
     dev: false
 
-  /concat-map@0.0.1:
-    resolution:
-      {
-        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
-
   /confbox@0.1.8:
     resolution:
       {
@@ -7074,14 +7316,12 @@ packages:
     engines: { node: '>= 0.6' }
     dev: false
 
-  /content-disposition@0.5.4:
+  /content-disposition@1.1.0:
     resolution:
       {
-        integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==,
+        integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==,
       }
-    engines: { node: '>= 0.6' }
-    dependencies:
-      safe-buffer: 5.2.1
+    engines: { node: '>=18' }
     dev: false
 
   /content-type@1.0.5:
@@ -7092,6 +7332,14 @@ packages:
     engines: { node: '>= 0.6' }
     dev: false
 
+  /content-type@2.0.0:
+    resolution:
+      {
+        integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==,
+      }
+    engines: { node: '>=18' }
+    dev: false
+
   /convert-source-map@2.0.0:
     resolution:
       {
@@ -7099,11 +7347,12 @@ packages:
       }
     dev: false
 
-  /cookie-signature@1.0.7:
+  /cookie-signature@1.2.2:
     resolution:
       {
-        integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==,
+        integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==,
       }
+    engines: { node: '>=6.6.0' }
     dev: false
 
   /cookie@0.7.2:
@@ -7129,14 +7378,14 @@ packages:
       }
     engines: { node: '>= 14.15.0' }
     peerDependencies:
-      webpack: ^5.1.0
+      webpack: '>=5.104.1'
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.7
       webpack: 5.105.3
     dev: false
 
@@ -7146,7 +7395,7 @@ packages:
         integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==,
       }
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.7
     dev: false
 
   /core-js@3.48.0:
@@ -7155,13 +7404,6 @@ packages:
         integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==,
       }
     requiresBuild: true
-    dev: false
-
-  /core-util-is@1.0.3:
-    resolution:
-      {
-        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
-      }
     dev: false
 
   /cose-base@1.0.3:
@@ -7195,7 +7437,7 @@ packages:
         optional: true
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 5.2.3
       parse-json: 5.2.0
       path-type: 4.0.0
     dev: false
@@ -7235,42 +7477,42 @@ packages:
       type-fest: 1.4.0
     dev: false
 
-  /css-blank-pseudo@7.0.1(postcss@8.5.6):
+  /css-blank-pseudo@7.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-jf+twWGDf6LDoXDUode+nc7ZlrqfaNphrBIBrcmeP3D8yw1uPaix1gCC8LUQUGQ6CycuK2opkbFFWFuq/a94ag==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /css-declaration-sorter@7.3.1(postcss@8.5.6):
+  /css-declaration-sorter@7.3.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==,
       }
     engines: { node: ^14 || ^16 || >=18 }
     peerDependencies:
-      postcss: ^8.0.9
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /css-has-pseudo@7.0.3(postcss@8.5.6):
+  /css-has-pseudo@7.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-oG+vKuGyqe/xvEMoxAQrhi7uY16deJR3i7wwhBerVrGQKSqUC5GiOVxTpM9F9B9hw0J+eKeOWLH7E9gZ1Dr5rA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
     dev: false
@@ -7283,19 +7525,19 @@ packages:
     engines: { node: '>= 12.13.0' }
     peerDependencies:
       '@rspack/core': 0.x || 1.x
-      webpack: ^5.0.0
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
       webpack:
         optional: true
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.26)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.26)
+      postcss-modules-scope: 3.2.1(postcss@8.5.26)
+      postcss-modules-values: 4.0.0(postcss@8.5.26)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
       webpack: 5.105.3
@@ -7314,7 +7556,7 @@ packages:
       csso: '*'
       esbuild: '*'
       lightningcss: '*'
-      webpack: ^5.0.0
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       '@parcel/css':
         optional: true
@@ -7331,24 +7573,24 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       clean-css: 5.3.3
-      cssnano: 6.1.2(postcss@8.5.6)
+      cssnano: 6.1.2(postcss@8.5.26)
       jest-worker: 29.7.0
-      postcss: 8.5.6
+      postcss: 8.5.26
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.7
       webpack: 5.105.3
     dev: false
 
-  /css-prefers-color-scheme@10.0.0(postcss@8.5.6):
+  /css-prefers-color-scheme@10.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-VCtXZAWivRglTZditUfB4StnsWr6YVZ2PRtuxQLKTNRdtAf8tpzaVPE9zXIF3VaSc7O70iK/j1+NXxyQCqdPjQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
   /css-select@4.3.0:
@@ -7395,14 +7637,14 @@ packages:
       source-map-js: 1.2.1
     dev: false
 
-  /css-tree@2.3.1:
+  /css-tree@3.2.1:
     resolution:
       {
-        integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==,
+        integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
       }
     engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
     dependencies:
-      mdn-data: 2.0.30
+      mdn-data: 2.27.1
       source-map-js: 1.2.1
     dev: false
 
@@ -7430,91 +7672,91 @@ packages:
     hasBin: true
     dev: false
 
-  /cssnano-preset-advanced@6.1.2(postcss@8.5.6):
+  /cssnano-preset-advanced@6.1.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      autoprefixer: 10.4.27(postcss@8.5.6)
+      autoprefixer: 10.4.27(postcss@8.5.26)
       browserslist: 4.28.1
-      cssnano-preset-default: 6.1.2(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-discard-unused: 6.0.5(postcss@8.5.6)
-      postcss-merge-idents: 6.0.3(postcss@8.5.6)
-      postcss-reduce-idents: 6.0.3(postcss@8.5.6)
-      postcss-zindex: 6.0.2(postcss@8.5.6)
+      cssnano-preset-default: 6.1.2(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-discard-unused: 6.0.5(postcss@8.5.26)
+      postcss-merge-idents: 6.0.3(postcss@8.5.26)
+      postcss-reduce-idents: 6.0.3(postcss@8.5.26)
+      postcss-zindex: 6.0.2(postcss@8.5.26)
     dev: false
 
-  /cssnano-preset-default@6.1.2(postcss@8.5.6):
+  /cssnano-preset-default@6.1.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
-      css-declaration-sorter: 7.3.1(postcss@8.5.6)
-      cssnano-utils: 4.0.2(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-calc: 9.0.1(postcss@8.5.6)
-      postcss-colormin: 6.1.0(postcss@8.5.6)
-      postcss-convert-values: 6.1.0(postcss@8.5.6)
-      postcss-discard-comments: 6.0.2(postcss@8.5.6)
-      postcss-discard-duplicates: 6.0.3(postcss@8.5.6)
-      postcss-discard-empty: 6.0.3(postcss@8.5.6)
-      postcss-discard-overridden: 6.0.2(postcss@8.5.6)
-      postcss-merge-longhand: 6.0.5(postcss@8.5.6)
-      postcss-merge-rules: 6.1.1(postcss@8.5.6)
-      postcss-minify-font-values: 6.1.0(postcss@8.5.6)
-      postcss-minify-gradients: 6.0.3(postcss@8.5.6)
-      postcss-minify-params: 6.1.0(postcss@8.5.6)
-      postcss-minify-selectors: 6.0.4(postcss@8.5.6)
-      postcss-normalize-charset: 6.0.2(postcss@8.5.6)
-      postcss-normalize-display-values: 6.0.2(postcss@8.5.6)
-      postcss-normalize-positions: 6.0.2(postcss@8.5.6)
-      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.6)
-      postcss-normalize-string: 6.0.2(postcss@8.5.6)
-      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.6)
-      postcss-normalize-unicode: 6.1.0(postcss@8.5.6)
-      postcss-normalize-url: 6.0.2(postcss@8.5.6)
-      postcss-normalize-whitespace: 6.0.2(postcss@8.5.6)
-      postcss-ordered-values: 6.0.2(postcss@8.5.6)
-      postcss-reduce-initial: 6.1.0(postcss@8.5.6)
-      postcss-reduce-transforms: 6.0.2(postcss@8.5.6)
-      postcss-svgo: 6.0.3(postcss@8.5.6)
-      postcss-unique-selectors: 6.0.4(postcss@8.5.6)
+      css-declaration-sorter: 7.3.1(postcss@8.5.26)
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-calc: 9.0.1(postcss@8.5.26)
+      postcss-colormin: 6.1.0(postcss@8.5.26)
+      postcss-convert-values: 6.1.0(postcss@8.5.26)
+      postcss-discard-comments: 6.0.2(postcss@8.5.26)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.26)
+      postcss-discard-empty: 6.0.3(postcss@8.5.26)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.26)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.26)
+      postcss-merge-rules: 6.1.1(postcss@8.5.26)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.26)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.26)
+      postcss-minify-params: 6.1.0(postcss@8.5.26)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.26)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.26)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.26)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.26)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.26)
+      postcss-normalize-string: 6.0.2(postcss@8.5.26)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.26)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.26)
+      postcss-normalize-url: 6.0.2(postcss@8.5.26)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.26)
+      postcss-ordered-values: 6.0.2(postcss@8.5.26)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.26)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.26)
+      postcss-svgo: 6.0.3(postcss@8.5.26)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.26)
     dev: false
 
-  /cssnano-utils@4.0.2(postcss@8.5.6):
+  /cssnano-utils@4.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /cssnano@6.1.2(postcss@8.5.6):
+  /cssnano@6.1.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      cssnano-preset-default: 6.1.2(postcss@8.5.6)
+      cssnano-preset-default: 6.1.2(postcss@8.5.26)
       lilconfig: 3.1.3
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
   /csso@5.0.5:
@@ -7534,7 +7776,7 @@ packages:
       }
     dev: false
 
-  /cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
+  /cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
     resolution:
       {
         integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==,
@@ -7543,10 +7785,10 @@ packages:
       cytoscape: ^3.2.0
     dependencies:
       cose-base: 1.0.3
-      cytoscape: 3.33.1
+      cytoscape: 3.34.0
     dev: false
 
-  /cytoscape-fcose@2.2.0(cytoscape@3.33.1):
+  /cytoscape-fcose@2.2.0(cytoscape@3.34.0):
     resolution:
       {
         integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==,
@@ -7555,13 +7797,13 @@ packages:
       cytoscape: ^3.2.0
     dependencies:
       cose-base: 2.2.0
-      cytoscape: 3.33.1
+      cytoscape: 3.34.0
     dev: false
 
-  /cytoscape@3.33.1:
+  /cytoscape@3.34.0:
     resolution:
       {
-        integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==,
+        integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==,
       }
     engines: { node: '>=0.10' }
     dev: false
@@ -7942,14 +8184,14 @@ packages:
       d3-zoom: 3.0.0
     dev: false
 
-  /dagre-d3-es@7.0.13:
+  /dagre-d3-es@7.0.14:
     resolution:
       {
-        integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==,
+        integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==,
       }
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
     dev: false
 
   /data-view-buffer@1.0.2:
@@ -7995,10 +8237,10 @@ packages:
       '@babel/runtime': 7.28.6
     dev: false
 
-  /dayjs@1.11.19:
+  /dayjs@1.11.21:
     resolution:
       {
-        integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==,
+        integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==,
       }
     dev: false
 
@@ -8192,21 +8434,6 @@ packages:
       }
     engines: { node: '>=6' }
 
-  /destroy@1.2.0:
-    resolution:
-      {
-        integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==,
-      }
-    engines: { node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16 }
-    dev: false
-
-  /detect-node@2.1.0:
-    resolution:
-      {
-        integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==,
-      }
-    dev: false
-
   /detect-port@2.1.0:
     resolution:
       {
@@ -8334,10 +8561,10 @@ packages:
       domelementtype: 2.3.0
     dev: false
 
-  /dompurify@3.3.1:
+  /dompurify@3.4.13:
     resolution:
       {
-        integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==,
+        integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==,
       }
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -8598,13 +8825,6 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  /es-module-lexer@1.7.0:
-    resolution:
-      {
-        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
-      }
-    dev: false
-
   /es-module-lexer@2.0.0:
     resolution:
       {
@@ -8649,6 +8869,13 @@ packages:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  /es-toolkit@1.50.0:
+    resolution:
+      {
+        integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==,
+      }
+    dev: false
 
   /esast-util-from-estree@2.0.0:
     resolution:
@@ -8896,43 +9123,40 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  /express@4.22.1:
+  /express@5.2.1:
     resolution:
       {
-        integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==,
+        integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==,
       }
-    engines: { node: '>= 0.10.0' }
+    engines: { node: '>= 18' }
     dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.4
-      content-disposition: 0.5.4
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
-      cookie-signature: 1.0.7
-      debug: 2.6.9
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@9.4.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
-      fresh: 0.5.2
+      finalhandler: 2.1.1
+      fresh: 2.0.0
       http-errors: 2.0.1
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
       on-finished: 2.4.1
+      once: 1.4.0
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.3
       range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.2
-      serve-static: 1.16.3
-      setprototypeof: 1.2.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
       statuses: 2.0.2
-      type-is: 1.6.18
-      utils-merge: 1.0.1
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8987,10 +9211,10 @@ packages:
       }
     dev: false
 
-  /fast-uri@3.1.0:
+  /fast-uri@4.1.2:
     resolution:
       {
-        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+        integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==,
       }
 
   /fastq@1.20.1:
@@ -9011,14 +9235,19 @@ packages:
       format: 0.2.2
     dev: false
 
-  /faye-websocket@0.11.4:
+  /fdir@6.5.0(picomatch@4.0.5):
     resolution:
       {
-        integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==,
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
       }
-    engines: { node: '>=0.8.0' }
+    engines: { node: '>=12.0.0' }
+    peerDependencies:
+      picomatch: '>=2.3.2'
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
     dependencies:
-      websocket-driver: 0.7.4
+      picomatch: 4.0.5
     dev: false
 
   /feed@4.2.2:
@@ -9038,7 +9267,7 @@ packages:
       }
     engines: { node: '>= 10.13.0' }
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '>=5.104.1'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -9054,20 +9283,19 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
-  /finalhandler@1.3.2:
+  /finalhandler@2.1.1:
     resolution:
       {
-        integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==,
+        integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==,
       }
-    engines: { node: '>= 0.8' }
+    engines: { node: '>= 18.0.0' }
     dependencies:
-      debug: 2.6.9
+      debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
       statuses: 2.0.2
-      unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9100,19 +9328,6 @@ packages:
         integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==,
       }
     hasBin: true
-    dev: false
-
-  /follow-redirects@1.15.11:
-    resolution:
-      {
-        integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==,
-      }
-    engines: { node: '>=4.0' }
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
     dev: false
 
   /for-each@0.3.5:
@@ -9155,12 +9370,12 @@ packages:
       }
     dev: false
 
-  /fresh@0.5.2:
+  /fresh@2.0.0:
     resolution:
       {
-        integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==,
+        integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==,
       }
-    engines: { node: '>= 0.6' }
+    engines: { node: '>= 0.8' }
     dev: false
 
   /fs-extra@11.3.3:
@@ -9429,13 +9644,6 @@ packages:
     resolution:
       {
         integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==,
-      }
-    dev: false
-
-  /handle-thing@2.0.1:
-    resolution:
-      {
-        integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==,
       }
     dev: false
 
@@ -9845,18 +10053,6 @@ packages:
       }
     dev: true
 
-  /hpack.js@2.1.6:
-    resolution:
-      {
-        integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==,
-      }
-    dependencies:
-      inherits: 2.0.4
-      obuf: 1.1.2
-      readable-stream: 2.3.8
-      wbuf: 1.7.3
-    dev: false
-
   /html-escaper@2.0.2:
     resolution:
       {
@@ -9921,7 +10117,7 @@ packages:
     engines: { node: '>=10.13.0' }
     peerDependencies:
       '@rspack/core': 0.x || 1.x
-      webpack: ^5.20.0
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -9930,7 +10126,7 @@ packages:
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.3.0
       webpack: 5.105.3
@@ -9967,13 +10163,6 @@ packages:
       }
     dev: false
 
-  /http-deceiver@1.2.7:
-    resolution:
-      {
-        integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==,
-      }
-    dev: false
-
   /http-errors@1.8.1:
     resolution:
       {
@@ -10002,47 +10191,20 @@ packages:
       toidentifier: 1.0.1
     dev: false
 
-  /http-parser-js@0.5.10:
+  /http-proxy-middleware@4.2.0:
     resolution:
       {
-        integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==,
+        integrity: sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==,
       }
-    dev: false
-
-  /http-proxy-middleware@2.0.9(@types/express@4.17.25):
-    resolution:
-      {
-        integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==,
-      }
-    engines: { node: '>=12.0.0' }
-    peerDependencies:
-      '@types/express': ^4.17.13
-    peerDependenciesMeta:
-      '@types/express':
-        optional: true
+    engines: { node: ^22.15.0 || ^24.0.0 || >=26.0.0 }
     dependencies:
-      '@types/express': 4.17.25
-      '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      debug: 4.4.3(supports-color@9.4.0)
+      httpxy: 0.5.5
       is-glob: 4.0.3
-      is-plain-obj: 3.0.0
+      is-plain-obj: 4.1.0
       micromatch: 4.0.8
     transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /http-proxy@1.18.1:
-    resolution:
-      {
-        integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==,
-      }
-    engines: { node: '>=8.0.0' }
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
-      requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
+      - supports-color
     dev: false
 
   /http2-wrapper@2.2.1:
@@ -10054,6 +10216,13 @@ packages:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
+    dev: false
+
+  /httpxy@0.5.5:
+    resolution:
+      {
+        integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==,
+      }
     dev: false
 
   /human-signals@2.1.0:
@@ -10080,16 +10249,6 @@ packages:
     engines: { node: '>=10.18' }
     dev: false
 
-  /iconv-lite@0.4.24:
-    resolution:
-      {
-        integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==,
-      }
-    engines: { node: '>=0.10.0' }
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: false
-
   /iconv-lite@0.6.3:
     resolution:
       {
@@ -10100,16 +10259,26 @@ packages:
       safer-buffer: 2.1.2
     dev: false
 
-  /icss-utils@5.1.0(postcss@8.5.6):
+  /iconv-lite@0.7.3:
+    resolution:
+      {
+        integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==,
+      }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /icss-utils@5.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==,
       }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
   /ignore@5.3.2:
@@ -10480,6 +10649,14 @@ packages:
         integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
       }
 
+  /is-in-ssh@1.0.0:
+    resolution:
+      {
+        integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==,
+      }
+    engines: { node: '>=20' }
+    dev: false
+
   /is-inside-container@1.0.0:
     resolution:
       {
@@ -10573,14 +10750,6 @@ packages:
     engines: { node: '>=8' }
     dev: false
 
-  /is-plain-obj@3.0.0:
-    resolution:
-      {
-        integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==,
-      }
-    engines: { node: '>=10' }
-    dev: false
-
   /is-plain-obj@4.1.0:
     resolution:
       {
@@ -10596,6 +10765,13 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       isobject: 3.0.1
+    dev: false
+
+  /is-promise@4.0.0:
+    resolution:
+      {
+        integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==,
+      }
     dev: false
 
   /is-regex@1.2.1:
@@ -10739,13 +10915,6 @@ packages:
       }
     dev: false
 
-  /isarray@1.0.0:
-    resolution:
-      {
-        integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==,
-      }
-    dev: false
-
   /isarray@2.0.5:
     resolution:
       {
@@ -10778,7 +10947,7 @@ packages:
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.1
+      picomatch: 4.0.5
     dev: false
 
   /jest-worker@27.5.1:
@@ -10813,17 +10982,27 @@ packages:
     hasBin: true
     dev: false
 
-  /joi@17.13.3:
+  /joi@18.2.3:
     resolution:
       {
-        integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==,
+        integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==,
       }
+    engines: { node: '>= 20' }
     dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.5
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.7
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
+    dev: false
+
+  /js-tokens@10.0.0:
+    resolution:
+      {
+        integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
+      }
     dev: false
 
   /js-tokens@4.0.0:
@@ -10833,10 +11012,10 @@ packages:
       }
     dev: false
 
-  /js-yaml@4.1.1:
+  /js-yaml@5.2.3:
     resolution:
       {
-        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+        integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==,
       }
     hasBin: true
     dependencies:
@@ -10911,10 +11090,10 @@ packages:
       graceful-fs: 4.2.11
     dev: false
 
-  /katex@0.16.33:
+  /katex@0.16.47:
     resolution:
       {
-        integrity: sha512-q3N5u+1sY9Bu7T4nlXoiRBXWfwSefNGoKeOwekV+gw0cAXQlz2Ww6BLcmBxVDeXBMUDQv6fK5bcNaJLxob3ZQA==,
+        integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==,
       }
     hasBin: true
     dependencies:
@@ -10953,20 +11132,6 @@ packages:
     engines: { node: '>=6' }
     dev: false
 
-  /langium@4.2.1:
-    resolution:
-      {
-        integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==,
-      }
-    engines: { node: '>=20.10.0', npm: '>=10.2.3' }
-    dependencies:
-      chevrotain: 11.1.1
-      chevrotain-allstar: 0.3.1(chevrotain@11.1.1)
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
-    dev: false
-
   /latest-version@7.0.0:
     resolution:
       {
@@ -10977,14 +11142,14 @@ packages:
       package-json: 8.1.1
     dev: false
 
-  /launch-editor@2.13.1:
+  /launch-editor@2.14.1:
     resolution:
       {
-        integrity: sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA==,
+        integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==,
       }
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.10.0
     dev: false
 
   /layout-base@1.0.2:
@@ -11053,7 +11218,7 @@ packages:
       pidtree: 0.5.0
       string-argv: 0.3.2
       supports-color: 9.4.0
-      yaml: 1.10.2
+      yaml: 2.9.0
     transitivePeerDependencies:
       - enquirer
     dev: true
@@ -11184,10 +11349,10 @@ packages:
       p-locate: 6.0.0
     dev: false
 
-  /lodash-es@4.17.23:
+  /lodash-es@4.18.1:
     resolution:
       {
-        integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==,
+        integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==,
       }
     dev: false
 
@@ -11212,10 +11377,10 @@ packages:
       }
     dev: false
 
-  /lodash@4.17.23:
+  /lodash@4.18.1:
     resolution:
       {
-        integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==,
+        integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
       }
     dev: false
 
@@ -11592,19 +11757,19 @@ packages:
       }
     dev: false
 
-  /mdn-data@2.0.30:
+  /mdn-data@2.27.1:
     resolution:
       {
-        integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==,
+        integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
     dev: false
 
-  /media-typer@0.3.0:
+  /media-typer@1.1.1:
     resolution:
       {
-        integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==,
+        integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==,
       }
-    engines: { node: '>= 0.6' }
+    engines: { node: '>= 0.8' }
     dev: false
 
   /memfs@4.56.10(tslib@2.8.1):
@@ -11639,11 +11804,12 @@ packages:
     engines: { node: '>= 0.10.0' }
     dev: true
 
-  /merge-descriptors@1.0.3:
+  /merge-descriptors@2.0.0:
     resolution:
       {
-        integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==,
+        integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==,
       }
+    engines: { node: '>=18' }
     dev: false
 
   /merge-stream@2.0.0:
@@ -11660,40 +11826,33 @@ packages:
     engines: { node: '>= 8' }
     dev: false
 
-  /mermaid@11.12.3:
+  /mermaid@11.16.1:
     resolution:
       {
-        integrity: sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==,
+        integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==,
       }
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 1.0.0
+      '@mermaid-js/parser': 1.2.0
       '@types/d3': 7.4.3
-      cytoscape: 3.33.1
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
-      cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
       d3: 7.9.0
       d3-sankey: 0.12.3
-      dagre-d3-es: 7.0.13
-      dayjs: 1.11.19
-      dompurify: 3.3.1
-      katex: 0.16.33
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.13
+      es-toolkit: 1.50.0
+      katex: 0.16.47
       khroma: 2.1.0
-      lodash-es: 4.17.23
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
-    dev: false
-
-  /methods@1.1.2:
-    resolution:
-      {
-        integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==,
-      }
-    engines: { node: '>= 0.6' }
+      uuid: 14.0.1
     dev: false
 
   /micromark-core-commonmark@2.0.3:
@@ -12183,7 +12342,7 @@ packages:
     engines: { node: '>=8.6' }
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 4.0.5
 
   /mime-db@1.33.0:
     resolution:
@@ -12238,15 +12397,6 @@ packages:
       mime-db: 1.54.0
     dev: false
 
-  /mime@1.6.0:
-    resolution:
-      {
-        integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==,
-      }
-    engines: { node: '>=4' }
-    hasBin: true
-    dev: false
-
   /mimic-fn@2.1.0:
     resolution:
       {
@@ -12277,18 +12427,11 @@ packages:
       }
     engines: { node: '>= 12.13.0' }
     peerDependencies:
-      webpack: ^5.0.0
+      webpack: '>=5.104.1'
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
       webpack: 5.105.3
-    dev: false
-
-  /minimalistic-assert@1.0.1:
-    resolution:
-      {
-        integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==,
-      }
     dev: false
 
   /minimatch@3.1.5:
@@ -12297,7 +12440,7 @@ packages:
         integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
       }
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 5.0.9
 
   /minimist@1.2.8:
     resolution:
@@ -12306,7 +12449,7 @@ packages:
       }
     dev: false
 
-  /minimizer-webpack-plugin@5.6.1(postcss@8.5.6)(webpack@5.109.2):
+  /minimizer-webpack-plugin@5.6.1(postcss@8.5.26)(webpack@5.109.2):
     resolution:
       {
         integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==,
@@ -12325,7 +12468,7 @@ packages:
       lightningcss: '*'
       postcss: '*'
       uglify-js: '*'
-      webpack: ^5.1.0
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       '@minify-html/node':
         optional: true
@@ -12354,10 +12497,10 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
-      postcss: 8.5.6
+      postcss: 8.5.26
       schema-utils: 4.3.3
       terser: 5.49.2
-      webpack: 5.109.2(postcss@8.5.6)
+      webpack: 5.109.2(postcss@8.5.26)
 
   /mlly@1.8.0:
     resolution:
@@ -12365,7 +12508,7 @@ packages:
         integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==,
       }
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.18.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
@@ -12378,11 +12521,11 @@ packages:
       }
     peerDependencies:
       monaco-editor: '>= 0.31.0'
-      webpack: ^4.5.0 || 5.x
+      webpack: '>=5.104.1'
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.52.2
-      webpack: 5.109.2(postcss@8.5.6)
+      webpack: 5.109.2(postcss@8.5.26)
     dev: false
 
   /monaco-editor@0.52.2:
@@ -12424,12 +12567,12 @@ packages:
       thunky: 1.1.0
     dev: false
 
-  /nanoid@3.3.11:
+  /nanoid@6.0.1:
     resolution:
       {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+        integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==,
       }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    engines: { node: ^22 || ^24 || >=26 }
     hasBin: true
 
   /negotiator@0.6.3:
@@ -12444,6 +12587,14 @@ packages:
     resolution:
       {
         integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: false
+
+  /negotiator@1.0.0:
+    resolution:
+      {
+        integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
       }
     engines: { node: '>= 0.6' }
     dev: false
@@ -12555,7 +12706,7 @@ packages:
       minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.10.0
       string.prototype.padend: 3.1.6
     dev: true
 
@@ -12591,7 +12742,7 @@ packages:
       }
     engines: { node: '>= 10.13.0' }
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '>=5.104.1'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -12634,11 +12785,12 @@ packages:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  /obuf@1.1.2:
+  /obug@2.1.4:
     resolution:
       {
-        integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==,
+        integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==,
       }
+    engines: { node: '>=12.20.0' }
     dev: false
 
   /on-finished@2.4.1:
@@ -12659,6 +12811,15 @@ packages:
     engines: { node: '>= 0.8' }
     dev: false
 
+  /once@1.4.0:
+    resolution:
+      {
+        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+      }
+    dependencies:
+      wrappy: 1.0.2
+    dev: false
+
   /onetime@5.1.2:
     resolution:
       {
@@ -12668,17 +12829,19 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
 
-  /open@10.2.0:
+  /open@11.0.0:
     resolution:
       {
-        integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==,
+        integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==,
       }
-    engines: { node: '>=18' }
+    engines: { node: '>=20' }
     dependencies:
       default-browser: 5.5.0
       define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
       is-inside-container: 1.0.0
-      wsl-utils: 0.1.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
     dev: false
 
   /open@8.4.2:
@@ -12796,16 +12959,14 @@ packages:
       p-timeout: 3.2.0
     dev: false
 
-  /p-retry@6.2.1:
+  /p-retry@8.0.0:
     resolution:
       {
-        integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==,
+        integrity: sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==,
       }
-    engines: { node: '>=16.17' }
+    engines: { node: '>=22' }
     dependencies:
-      '@types/retry': 0.12.2
       is-network-error: 1.3.1
-      retry: 0.13.1
     dev: false
 
   /p-timeout@3.2.0:
@@ -12983,13 +13144,6 @@ packages:
         integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
       }
 
-  /path-to-regexp@0.1.12:
-    resolution:
-      {
-        integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==,
-      }
-    dev: false
-
   /path-to-regexp@1.9.0:
     resolution:
       {
@@ -13037,12 +13191,12 @@ packages:
         integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
       }
 
-  /picomatch@2.3.1:
+  /picomatch@4.0.5:
     resolution:
       {
-        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+        integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==,
       }
-    engines: { node: '>=8.6' }
+    engines: { node: '>=12' }
 
   /pidtree@0.3.1:
     resolution:
@@ -13130,876 +13284,876 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  /postcss-attribute-case-insensitive@7.0.1(postcss@8.5.6):
+  /postcss-attribute-case-insensitive@7.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-Uai+SupNSqzlschRyNx3kbCTWgY/2hcwtHEI/ej2LJWc9JJ77qKgGptd8DHwY1mXtZ7Aoh4z4yxfwMBue9eNgw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-calc@9.0.1(postcss@8.5.6):
+  /postcss-calc@9.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.2.2
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-clamp@4.1.0(postcss@8.5.6):
+  /postcss-clamp@4.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-ry4b1Llo/9zz+PKC+030KUnPITTJAHeOwjfAyyB60eT0AorGLdzp52s31OsPRHRf8NchkgFoG2y6fCfn1IV1Ow==,
       }
     engines: { node: '>=7.6.0' }
     peerDependencies:
-      postcss: ^8.4.6
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-color-functional-notation@7.0.12(postcss@8.5.6):
+  /postcss-color-functional-notation@7.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-TLCW9fN5kvO/u38/uesdpbx3e8AkTYhMvDZYa9JpmImWuTE99bDQ7GU7hdOADIZsiI9/zuxfAJxny/khknp1Zw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /postcss-color-hex-alpha@10.0.0(postcss@8.5.6):
+  /postcss-color-hex-alpha@10.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-1kervM2cnlgPs2a8Vt/Qbe5cQ++N7rkYo/2rz2BkqJZIHQwaVuJgQH38REHrAi4uM0b1fqxMkWYmese94iMp3w==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-color-rebeccapurple@10.0.0(postcss@8.5.6):
+  /postcss-color-rebeccapurple@10.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-JFta737jSP+hdAIEhk1Vs0q0YF5P8fFcj+09pweS8ktuGuZ8pPlykHsk6mPxZ8awDl4TrcxUqJo9l1IhVr/OjQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-colormin@6.1.0(postcss@8.5.6):
+  /postcss-colormin@6.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-convert-values@6.1.0(postcss@8.5.6):
+  /postcss-convert-values@6.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-custom-media@11.0.6(postcss@8.5.6):
+  /postcss-custom-media@11.0.6(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-C4lD4b7mUIw+RZhtY7qUbf4eADmb7Ey8BFA2px9jUbwg7pjTZDl4KY4bvlUV+/vXQvzQRfiGEVJyAbtOsCMInw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.5(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-custom-properties@14.0.6(postcss@8.5.6):
+  /postcss-custom-properties@14.0.6(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-fTYSp3xuk4BUeVhxCSJdIPhDLpJfNakZKoiTDx7yRGCdlZrSJR7mWKVOBS4sBF+5poPQFMj2YdXx1VHItBGihQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.5(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-custom-selectors@8.0.5(postcss@8.5.6):
+  /postcss-custom-selectors@8.0.5(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-9PGmckHQswiB2usSO6XMSswO2yFWVoCAuih1yl9FVcwkscLjRKjwsjM3t+NIWpSU2Jx3eOiK2+t4vVTQaoCHHg==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.5(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-dir-pseudo-class@9.0.1(postcss@8.5.6):
+  /postcss-dir-pseudo-class@9.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-tRBEK0MHYvcMUrAuYMEOa0zg9APqirBcgzi6P21OhxtJyJADo/SWBwY1CAwEohQ/6HDaa9jCjLRG7K3PVQYHEA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-discard-comments@6.0.2(postcss@8.5.6):
+  /postcss-discard-comments@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-discard-duplicates@6.0.3(postcss@8.5.6):
+  /postcss-discard-duplicates@6.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-discard-empty@6.0.3(postcss@8.5.6):
+  /postcss-discard-empty@6.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-discard-overridden@6.0.2(postcss@8.5.6):
+  /postcss-discard-overridden@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-discard-unused@6.0.5(postcss@8.5.6):
+  /postcss-discard-unused@6.0.5(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-wHalBlRHkaNnNwfC8z+ppX57VhvS+HWgjW508esjdaEYr3Mx7Gnn2xA4R/CKf5+Z9S5qsqC+Uzh4ueENWwCVUA==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
     dev: false
 
-  /postcss-double-position-gradients@6.0.4(postcss@8.5.6):
+  /postcss-double-position-gradients@6.0.4(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-m6IKmxo7FxSP5nF2l63QbCC3r+bWpFUWmZXZf096WxG0m7Vl1Q1+ruFOhpdDRmKrRS+S3Jtk+TVk/7z0+BVK6g==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-focus-visible@10.0.1(postcss@8.5.6):
+  /postcss-focus-visible@10.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-U58wyjS/I1GZgjRok33aE8juW9qQgQUNwTSdxQGuShHzwuYdcklnvK/+qOWX1Q9kr7ysbraQ6ht6r+udansalA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-focus-within@9.0.1(postcss@8.5.6):
+  /postcss-focus-within@9.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-fzNUyS1yOYa7mOjpci/bR+u+ESvdar6hk8XNK/TRR0fiGTp2QT5N+ducP0n3rfH/m9I7H/EQU6lsa2BrgxkEjw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-font-variant@5.0.0(postcss@8.5.6):
+  /postcss-font-variant@5.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==,
       }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-gap-properties@6.0.0(postcss@8.5.6):
+  /postcss-gap-properties@6.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-Om0WPjEwiM9Ru+VhfEDPZJAKWUd0mV1HmNXqp2C29z80aQ2uP9UVhLc7e3aYMIor/S5cVhoPgYQ7RtfeZpYTRw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-image-set-function@7.0.0(postcss@8.5.6):
+  /postcss-image-set-function@7.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-QL7W7QNlZuzOwBTeXEmbVckNt1FSmhQtbMRvGGqqU4Nf4xk6KUEQhAoWuMzwbSv5jxiRiSZ5Tv7eiDB9U87znA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-lab-function@7.0.12(postcss@8.5.6):
+  /postcss-lab-function@7.0.12(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-tUcyRk1ZTPec3OuKFsqtRzW2Go5lehW29XA21lZ65XmzQkz43VY2tyWEC202F7W3mILOjw0voOiuxRGTsN+J9w==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/utilities': 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /postcss-loader@7.3.4(postcss@8.5.6)(webpack@5.105.3):
+  /postcss-loader@7.3.4(postcss@8.5.26)(webpack@5.105.3):
     resolution:
       {
         integrity: sha512-iW5WTTBSC5BfsBJ9daFMPVrLT36MrNiC6fqOZTTaHjBNX6Pfd5p+hSBqe/fEeNd7pc13QiAyGt7VdGMw4eRC4A==,
       }
     engines: { node: '>= 14.15.0' }
     peerDependencies:
-      postcss: ^7.0.0 || ^8.0.1
-      webpack: ^5.0.0
+      postcss: '>=8.5.23'
+      webpack: '>=5.104.1'
     dependencies:
       cosmiconfig: 8.3.6
       jiti: 1.21.7
-      postcss: 8.5.6
+      postcss: 8.5.26
       semver: 7.7.4
       webpack: 5.105.3
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /postcss-logical@8.1.0(postcss@8.5.6):
+  /postcss-logical@8.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-pL1hXFQ2fEXNKiNiAgtfA005T9FBxky5zkX6s4GZM2D8RkVgRqz3f4g1JUoq925zXv495qk8UNldDwh8uGEDoA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-merge-idents@6.0.3(postcss@8.5.6):
+  /postcss-merge-idents@6.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-1oIoAsODUs6IHQZkLQGO15uGEbK3EAl5wi9SS8hs45VgsxQfMnxvt+L+zIr7ifZFIH14cfAeVe2uCTa+SPRa3g==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-merge-longhand@6.0.5(postcss@8.5.6):
+  /postcss-merge-longhand@6.0.5(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
-      stylehacks: 6.1.1(postcss@8.5.6)
+      stylehacks: 6.1.1(postcss@8.5.26)
     dev: false
 
-  /postcss-merge-rules@6.1.1(postcss@8.5.6):
+  /postcss-merge-rules@6.1.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
-      cssnano-utils: 4.0.2(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
     dev: false
 
-  /postcss-minify-font-values@6.1.0(postcss@8.5.6):
+  /postcss-minify-font-values@6.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-minify-gradients@6.0.3(postcss@8.5.6):
+  /postcss-minify-gradients@6.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 4.0.2(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-minify-params@6.1.0(postcss@8.5.6):
+  /postcss-minify-params@6.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
-      cssnano-utils: 4.0.2(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-minify-selectors@6.0.4(postcss@8.5.6):
+  /postcss-minify-selectors@6.0.4(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
     dev: false
 
-  /postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
+  /postcss-modules-extract-imports@3.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==,
       }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
+  /postcss-modules-local-by-default@4.2.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==,
       }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.23'
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-modules-scope@3.2.1(postcss@8.5.6):
+  /postcss-modules-scope@3.2.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==,
       }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-modules-values@4.0.0(postcss@8.5.6):
+  /postcss-modules-values@4.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==,
       }
     engines: { node: ^10 || ^12 || >= 14 }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.23'
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
     dev: false
 
-  /postcss-nesting@13.0.2(postcss@8.5.6):
+  /postcss-nesting@13.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
       '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.1)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-normalize-charset@6.0.2(postcss@8.5.6):
+  /postcss-normalize-charset@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-normalize-display-values@6.0.2(postcss@8.5.6):
+  /postcss-normalize-display-values@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-positions@6.0.2(postcss@8.5.6):
+  /postcss-normalize-positions@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-repeat-style@6.0.2(postcss@8.5.6):
+  /postcss-normalize-repeat-style@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-string@6.0.2(postcss@8.5.6):
+  /postcss-normalize-string@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-timing-functions@6.0.2(postcss@8.5.6):
+  /postcss-normalize-timing-functions@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-unicode@6.1.0(postcss@8.5.6):
+  /postcss-normalize-unicode@6.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-url@6.0.2(postcss@8.5.6):
+  /postcss-normalize-url@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-whitespace@6.0.2(postcss@8.5.6):
+  /postcss-normalize-whitespace@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-opacity-percentage@3.0.0(postcss@8.5.6):
+  /postcss-opacity-percentage@3.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-K6HGVzyxUxd/VgZdX04DCtdwWJ4NGLG212US4/LA1TLAbHgmAsTWVR86o+gGIbFtnTkfOpb9sCRBx8K7HO66qQ==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-ordered-values@6.0.2(postcss@8.5.6):
+  /postcss-ordered-values@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.6)
-      postcss: 8.5.6
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-overflow-shorthand@6.0.0(postcss@8.5.6):
+  /postcss-overflow-shorthand@6.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-BdDl/AbVkDjoTofzDQnwDdm/Ym6oS9KgmO7Gr+LHYjNWJ6ExORe4+3pcLQsLA9gIROMkiGVjjwZNoL/mpXHd5Q==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-page-break@3.0.4(postcss@8.5.6):
+  /postcss-page-break@3.0.4(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==,
       }
     peerDependencies:
-      postcss: ^8
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-place@10.0.0(postcss@8.5.6):
+  /postcss-place@10.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-5EBrMzat2pPAxQNWYavwAfoKfYcTADJ8AXGVPcUZ2UkNloUTWzJQExgrzrDkh3EKzmAx1evfTAzF9I8NGcc+qw==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-preset-env@10.6.1(postcss@8.5.6):
+  /postcss-preset-env@10.6.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      '@csstools/postcss-alpha-function': 1.0.1(postcss@8.5.6)
-      '@csstools/postcss-cascade-layers': 5.0.2(postcss@8.5.6)
-      '@csstools/postcss-color-function': 4.0.12(postcss@8.5.6)
-      '@csstools/postcss-color-function-display-p3-linear': 1.0.1(postcss@8.5.6)
-      '@csstools/postcss-color-mix-function': 3.0.12(postcss@8.5.6)
-      '@csstools/postcss-color-mix-variadic-function-arguments': 1.0.2(postcss@8.5.6)
-      '@csstools/postcss-content-alt-text': 2.0.8(postcss@8.5.6)
-      '@csstools/postcss-contrast-color-function': 2.0.12(postcss@8.5.6)
-      '@csstools/postcss-exponential-functions': 2.0.9(postcss@8.5.6)
-      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.5.6)
-      '@csstools/postcss-gamut-mapping': 2.0.11(postcss@8.5.6)
-      '@csstools/postcss-gradients-interpolation-method': 5.0.12(postcss@8.5.6)
-      '@csstools/postcss-hwb-function': 4.0.12(postcss@8.5.6)
-      '@csstools/postcss-ic-unit': 4.0.4(postcss@8.5.6)
-      '@csstools/postcss-initial': 2.0.1(postcss@8.5.6)
-      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.6)
-      '@csstools/postcss-light-dark-function': 2.0.11(postcss@8.5.6)
-      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.5.6)
-      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.5.6)
-      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.5.6)
-      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.5.6)
-      '@csstools/postcss-logical-viewport-units': 3.0.4(postcss@8.5.6)
-      '@csstools/postcss-media-minmax': 2.0.9(postcss@8.5.6)
-      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.5(postcss@8.5.6)
-      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.5.6)
-      '@csstools/postcss-normalize-display-values': 4.0.1(postcss@8.5.6)
-      '@csstools/postcss-oklab-function': 4.0.12(postcss@8.5.6)
-      '@csstools/postcss-position-area-property': 1.0.0(postcss@8.5.6)
-      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.6)
-      '@csstools/postcss-property-rule-prelude-list': 1.0.0(postcss@8.5.6)
-      '@csstools/postcss-random-function': 2.0.1(postcss@8.5.6)
-      '@csstools/postcss-relative-color-syntax': 3.0.12(postcss@8.5.6)
-      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.5.6)
-      '@csstools/postcss-sign-functions': 1.1.4(postcss@8.5.6)
-      '@csstools/postcss-stepped-value-functions': 4.0.9(postcss@8.5.6)
-      '@csstools/postcss-syntax-descriptor-syntax-production': 1.0.1(postcss@8.5.6)
-      '@csstools/postcss-system-ui-font-family': 1.0.0(postcss@8.5.6)
-      '@csstools/postcss-text-decoration-shorthand': 4.0.3(postcss@8.5.6)
-      '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.6)
-      '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.6)
-      autoprefixer: 10.4.27(postcss@8.5.6)
+      '@csstools/postcss-alpha-function': 1.0.1(postcss@8.5.26)
+      '@csstools/postcss-cascade-layers': 5.0.2(postcss@8.5.26)
+      '@csstools/postcss-color-function': 4.0.12(postcss@8.5.26)
+      '@csstools/postcss-color-function-display-p3-linear': 1.0.1(postcss@8.5.26)
+      '@csstools/postcss-color-mix-function': 3.0.12(postcss@8.5.26)
+      '@csstools/postcss-color-mix-variadic-function-arguments': 1.0.2(postcss@8.5.26)
+      '@csstools/postcss-content-alt-text': 2.0.8(postcss@8.5.26)
+      '@csstools/postcss-contrast-color-function': 2.0.12(postcss@8.5.26)
+      '@csstools/postcss-exponential-functions': 2.0.9(postcss@8.5.26)
+      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.5.26)
+      '@csstools/postcss-gamut-mapping': 2.0.11(postcss@8.5.26)
+      '@csstools/postcss-gradients-interpolation-method': 5.0.12(postcss@8.5.26)
+      '@csstools/postcss-hwb-function': 4.0.12(postcss@8.5.26)
+      '@csstools/postcss-ic-unit': 4.0.4(postcss@8.5.26)
+      '@csstools/postcss-initial': 2.0.1(postcss@8.5.26)
+      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.26)
+      '@csstools/postcss-light-dark-function': 2.0.11(postcss@8.5.26)
+      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.5.26)
+      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.5.26)
+      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.5.26)
+      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.5.26)
+      '@csstools/postcss-logical-viewport-units': 3.0.4(postcss@8.5.26)
+      '@csstools/postcss-media-minmax': 2.0.9(postcss@8.5.26)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.5(postcss@8.5.26)
+      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.5.26)
+      '@csstools/postcss-normalize-display-values': 4.0.1(postcss@8.5.26)
+      '@csstools/postcss-oklab-function': 4.0.12(postcss@8.5.26)
+      '@csstools/postcss-position-area-property': 1.0.0(postcss@8.5.26)
+      '@csstools/postcss-progressive-custom-properties': 4.2.1(postcss@8.5.26)
+      '@csstools/postcss-property-rule-prelude-list': 1.0.0(postcss@8.5.26)
+      '@csstools/postcss-random-function': 2.0.1(postcss@8.5.26)
+      '@csstools/postcss-relative-color-syntax': 3.0.12(postcss@8.5.26)
+      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.5.26)
+      '@csstools/postcss-sign-functions': 1.1.4(postcss@8.5.26)
+      '@csstools/postcss-stepped-value-functions': 4.0.9(postcss@8.5.26)
+      '@csstools/postcss-syntax-descriptor-syntax-production': 1.0.1(postcss@8.5.26)
+      '@csstools/postcss-system-ui-font-family': 1.0.0(postcss@8.5.26)
+      '@csstools/postcss-text-decoration-shorthand': 4.0.3(postcss@8.5.26)
+      '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.26)
+      '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.26)
+      autoprefixer: 10.4.27(postcss@8.5.26)
       browserslist: 4.28.1
-      css-blank-pseudo: 7.0.1(postcss@8.5.6)
-      css-has-pseudo: 7.0.3(postcss@8.5.6)
-      css-prefers-color-scheme: 10.0.0(postcss@8.5.6)
+      css-blank-pseudo: 7.0.1(postcss@8.5.26)
+      css-has-pseudo: 7.0.3(postcss@8.5.26)
+      css-prefers-color-scheme: 10.0.0(postcss@8.5.26)
       cssdb: 8.8.0
-      postcss: 8.5.6
-      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.6)
-      postcss-clamp: 4.1.0(postcss@8.5.6)
-      postcss-color-functional-notation: 7.0.12(postcss@8.5.6)
-      postcss-color-hex-alpha: 10.0.0(postcss@8.5.6)
-      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.6)
-      postcss-custom-media: 11.0.6(postcss@8.5.6)
-      postcss-custom-properties: 14.0.6(postcss@8.5.6)
-      postcss-custom-selectors: 8.0.5(postcss@8.5.6)
-      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.6)
-      postcss-double-position-gradients: 6.0.4(postcss@8.5.6)
-      postcss-focus-visible: 10.0.1(postcss@8.5.6)
-      postcss-focus-within: 9.0.1(postcss@8.5.6)
-      postcss-font-variant: 5.0.0(postcss@8.5.6)
-      postcss-gap-properties: 6.0.0(postcss@8.5.6)
-      postcss-image-set-function: 7.0.0(postcss@8.5.6)
-      postcss-lab-function: 7.0.12(postcss@8.5.6)
-      postcss-logical: 8.1.0(postcss@8.5.6)
-      postcss-nesting: 13.0.2(postcss@8.5.6)
-      postcss-opacity-percentage: 3.0.0(postcss@8.5.6)
-      postcss-overflow-shorthand: 6.0.0(postcss@8.5.6)
-      postcss-page-break: 3.0.4(postcss@8.5.6)
-      postcss-place: 10.0.0(postcss@8.5.6)
-      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.6)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.6)
-      postcss-selector-not: 8.0.1(postcss@8.5.6)
+      postcss: 8.5.26
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.26)
+      postcss-clamp: 4.1.0(postcss@8.5.26)
+      postcss-color-functional-notation: 7.0.12(postcss@8.5.26)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.5.26)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.26)
+      postcss-custom-media: 11.0.6(postcss@8.5.26)
+      postcss-custom-properties: 14.0.6(postcss@8.5.26)
+      postcss-custom-selectors: 8.0.5(postcss@8.5.26)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.26)
+      postcss-double-position-gradients: 6.0.4(postcss@8.5.26)
+      postcss-focus-visible: 10.0.1(postcss@8.5.26)
+      postcss-focus-within: 9.0.1(postcss@8.5.26)
+      postcss-font-variant: 5.0.0(postcss@8.5.26)
+      postcss-gap-properties: 6.0.0(postcss@8.5.26)
+      postcss-image-set-function: 7.0.0(postcss@8.5.26)
+      postcss-lab-function: 7.0.12(postcss@8.5.26)
+      postcss-logical: 8.1.0(postcss@8.5.26)
+      postcss-nesting: 13.0.2(postcss@8.5.26)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.26)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.5.26)
+      postcss-page-break: 3.0.4(postcss@8.5.26)
+      postcss-place: 10.0.0(postcss@8.5.26)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.26)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.26)
+      postcss-selector-not: 8.0.1(postcss@8.5.26)
     dev: false
 
-  /postcss-pseudo-class-any-link@10.0.1(postcss@8.5.6):
+  /postcss-pseudo-class-any-link@10.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-3el9rXlBOqTFaMFkWDOkHUTQekFIYnaQY55Rsp8As8QQkpiSgIYEcF/6Ond93oHiDsGb4kad8zjt+NPlOC1H0Q==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
-  /postcss-reduce-idents@6.0.3(postcss@8.5.6):
+  /postcss-reduce-idents@6.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-G3yCqZDpsNPoQgbDUy3T0E6hqOQ5xigUtBQyrmq3tn2GxlyiL0yyl7H+T8ulQR6kOcHJ9t7/9H4/R2tv8tJbMA==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-reduce-initial@6.1.0(postcss@8.5.6):
+  /postcss-reduce-initial@6.1.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
       caniuse-api: 3.0.0
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-reduce-transforms@6.0.2(postcss@8.5.6):
+  /postcss-reduce-transforms@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-replace-overflow-wrap@4.0.0(postcss@8.5.6):
+  /postcss-replace-overflow-wrap@4.0.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==,
       }
     peerDependencies:
-      postcss: ^8.0.3
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss-selector-not@8.0.1(postcss@8.5.6):
+  /postcss-selector-not@8.0.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-kmVy/5PYVb2UOhy0+LqUYAhKj7DUGDpSWa5LZqlkWJaaAV+dxxsOG3+St0yNLu6vsKD7Dmqx+nWQt0iil89+WA==,
       }
     engines: { node: '>=18' }
     peerDependencies:
-      postcss: ^8.4
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
     dev: false
 
@@ -14025,43 +14179,43 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /postcss-sort-media-queries@5.2.0(postcss@8.5.6):
+  /postcss-sort-media-queries@5.2.0(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-AZ5fDMLD8SldlAYlvi8NIqo0+Z8xnXU2ia0jxmuhxAU+Lqt9K+AlmLNJ/zWEnE9x+Zx3qL3+1K20ATgNOr3fAA==,
       }
     engines: { node: '>=14.0.0' }
     peerDependencies:
-      postcss: ^8.4.23
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       sort-css-media-queries: 2.2.0
     dev: false
 
-  /postcss-svgo@6.0.3(postcss@8.5.6):
+  /postcss-svgo@6.0.3(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==,
       }
     engines: { node: ^14 || ^16 || >= 18 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
-      svgo: 3.3.2
+      svgo: 4.0.2
     dev: false
 
-  /postcss-unique-selectors@6.0.4(postcss@8.5.6):
+  /postcss-unique-selectors@6.0.4(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
     dev: false
 
@@ -14072,28 +14226,36 @@ packages:
       }
     dev: false
 
-  /postcss-zindex@6.0.2(postcss@8.5.6):
+  /postcss-zindex@6.0.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.26
     dev: false
 
-  /postcss@8.5.6:
+  /postcss@8.5.26:
     resolution:
       {
-        integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
+        integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==,
       }
     engines: { node: ^10 || ^12 || >=14 }
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 6.0.1
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  /powershell-utils@0.1.0:
+    resolution:
+      {
+        integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==,
+      }
+    engines: { node: '>=20' }
+    dev: false
 
   /prettier@2.8.8:
     resolution:
@@ -14110,7 +14272,7 @@ packages:
         integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==,
       }
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       renderkid: 3.0.0
     dev: false
 
@@ -14141,13 +14303,6 @@ packages:
         integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==,
       }
     engines: { node: '>=6' }
-    dev: false
-
-  /process-nextick-args@2.0.1:
-    resolution:
-      {
-        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
-      }
     dev: false
 
   /prompts@2.4.2:
@@ -14231,14 +14386,15 @@ packages:
     engines: { node: '>=16.0.0' }
     dev: false
 
-  /qs@6.14.2:
+  /qs@6.15.3:
     resolution:
       {
-        integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==,
+        integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==,
       }
     engines: { node: '>=0.6' }
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
     dev: false
 
   /queue-microtask@1.2.3:
@@ -14254,15 +14410,6 @@ packages:
         integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==,
       }
     engines: { node: '>=10' }
-    dev: false
-
-  /randombytes@2.1.0:
-    resolution:
-      {
-        integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==,
-      }
-    dependencies:
-      safe-buffer: 5.2.1
     dev: false
 
   /range-parser@1.2.0:
@@ -14281,16 +14428,16 @@ packages:
     engines: { node: '>= 0.6' }
     dev: false
 
-  /raw-body@2.5.3:
+  /raw-body@3.0.2:
     resolution:
       {
-        integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==,
+        integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==,
       }
-    engines: { node: '>= 0.8' }
+    engines: { node: '>= 0.10' }
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.4.24
+      iconv-lite: 0.7.3
       unpipe: 1.0.0
     dev: false
 
@@ -14301,11 +14448,11 @@ packages:
       }
     engines: { node: '>= 10.13.0' }
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '>=5.104.1'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.109.2(postcss@8.5.6)
+      webpack: 5.109.2(postcss@8.5.26)
     dev: true
 
   /rc@1.2.8:
@@ -14368,7 +14515,7 @@ packages:
     engines: { node: '>=10.13.0' }
     peerDependencies:
       react-loadable: '*'
-      webpack: '>=4.41.1 || 5.x'
+      webpack: '>=5.104.1'
     dependencies:
       '@babel/runtime': 7.28.6
       react-loadable: /@docusaurus/react-loadable@6.0.0(react@18.3.1)
@@ -14478,33 +14625,6 @@ packages:
       path-type: 3.0.0
     dev: true
 
-  /readable-stream@2.3.8:
-    resolution:
-      {
-        integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==,
-      }
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-    dev: false
-
-  /readable-stream@3.6.2:
-    resolution:
-      {
-        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
-      }
-    engines: { node: '>= 6' }
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-    dev: false
-
   /readdirp@3.6.0:
     resolution:
       {
@@ -14512,7 +14632,15 @@ packages:
       }
     engines: { node: '>=8.10.0' }
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 4.0.5
+    dev: false
+
+  /readdirp@5.1.1:
+    resolution:
+      {
+        integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==,
+      }
+    engines: { node: '>= 20.19.0' }
     dev: false
 
   /recma-build-jsx@1.0.0:
@@ -14870,7 +14998,7 @@ packages:
       css-select: 4.3.0
       dom-converter: 0.2.0
       htmlparser2: 6.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       strip-ansi: 6.0.1
     dev: false
 
@@ -14885,13 +15013,6 @@ packages:
     resolution:
       {
         integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==,
-      }
-    dev: false
-
-  /requires-port@1.0.0:
-    resolution:
-      {
-        integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==,
       }
     dev: false
 
@@ -14950,14 +15071,6 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /retry@0.13.1:
-    resolution:
-      {
-        integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==,
-      }
-    engines: { node: '>= 4' }
-    dev: false
-
   /reusify@1.1.0:
     resolution:
       {
@@ -14992,6 +15105,22 @@ packages:
       points-on-path: 0.2.1
     dev: false
 
+  /router@2.2.0:
+    resolution:
+      {
+        integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      debug: 4.4.3(supports-color@9.4.0)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 3.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /rtlcss@4.3.0:
     resolution:
       {
@@ -15002,7 +15131,7 @@ packages:
     dependencies:
       escalade: 3.2.0
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.26
       strip-json-comments: 3.1.1
     dev: false
 
@@ -15052,13 +15181,6 @@ packages:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
-  /safe-buffer@5.1.2:
-    resolution:
-      {
-        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
-      }
-    dev: false
-
   /safe-buffer@5.2.1:
     resolution:
       {
@@ -15105,6 +15227,14 @@ packages:
     resolution:
       {
         integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==,
+      }
+    engines: { node: '>=11.0.0' }
+    dev: false
+
+  /sax@1.6.1:
+    resolution:
+      {
+        integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==,
       }
     engines: { node: '>=11.0.0' }
     dev: false
@@ -15166,13 +15296,6 @@ packages:
       kind-of: 6.0.3
     dev: false
 
-  /select-hose@2.0.0:
-    resolution:
-      {
-        integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==,
-      }
-    dev: false
-
   /selfsigned@5.5.0:
     resolution:
       {
@@ -15219,22 +15342,20 @@ packages:
     hasBin: true
     dev: false
 
-  /send@0.19.2:
+  /send@1.2.1:
     resolution:
       {
-        integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==,
+        integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==,
       }
-    engines: { node: '>= 0.8.0' }
+    engines: { node: '>= 18' }
     dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
+      debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      fresh: 0.5.2
+      fresh: 2.0.0
       http-errors: 2.0.1
-      mime: 1.6.0
+      mime-types: 3.0.2
       ms: 2.1.3
       on-finished: 2.4.1
       range-parser: 1.2.1
@@ -15243,13 +15364,12 @@ packages:
       - supports-color
     dev: false
 
-  /serialize-javascript@6.0.2:
+  /serialize-javascript@7.0.7:
     resolution:
       {
-        integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==,
+        integrity: sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==,
       }
-    dependencies:
-      randombytes: 2.1.0
+    engines: { node: '>=20.0.0' }
     dev: false
 
   /serve-handler@6.1.7:
@@ -15285,17 +15405,17 @@ packages:
       - supports-color
     dev: false
 
-  /serve-static@1.16.3:
+  /serve-static@2.2.1:
     resolution:
       {
-        integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==,
+        integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==,
       }
-    engines: { node: '>= 0.8.0' }
+    engines: { node: '>= 18' }
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -15395,10 +15515,10 @@ packages:
       }
     engines: { node: '>=8' }
 
-  /shell-quote@1.8.3:
+  /shell-quote@1.10.0:
     resolution:
       {
-        integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==,
+        integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==,
       }
     engines: { node: '>= 0.4' }
 
@@ -15411,6 +15531,17 @@ packages:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
+
+  /side-channel-list@1.0.1:
+    resolution:
+      {
+        integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==,
+      }
+    engines: { node: '>= 0.4' }
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    dev: false
 
   /side-channel-map@1.0.1:
     resolution:
@@ -15449,6 +15580,20 @@ packages:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  /side-channel@1.1.1:
+    resolution:
+      {
+        integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==,
+      }
+    engines: { node: '>= 0.4' }
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    dev: false
 
   /signal-exit@3.0.7:
     resolution:
@@ -15560,17 +15705,6 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /sockjs@0.3.24:
-    resolution:
-      {
-        integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==,
-      }
-    dependencies:
-      faye-websocket: 0.11.4
-      uuid: 8.3.2
-      websocket-driver: 0.7.4
-    dev: false
-
   /sort-css-media-queries@2.2.0:
     resolution:
       {
@@ -15650,38 +15784,6 @@ packages:
         integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==,
       }
     dev: true
-
-  /spdy-transport@3.0.0:
-    resolution:
-      {
-        integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==,
-      }
-    dependencies:
-      debug: 4.4.3(supports-color@9.4.0)
-      detect-node: 2.1.0
-      hpack.js: 2.1.6
-      obuf: 1.1.2
-      readable-stream: 3.6.2
-      wbuf: 1.7.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /spdy@4.0.2:
-    resolution:
-      {
-        integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==,
-      }
-    engines: { node: '>=6.0.0' }
-    dependencies:
-      debug: 4.4.3(supports-color@9.4.0)
-      handle-thing: 2.0.1
-      http-deceiver: 1.2.7
-      select-hose: 2.0.0
-      spdy-transport: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /srcset@4.0.0:
     resolution:
@@ -15805,24 +15907,6 @@ packages:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  /string_decoder@1.1.1:
-    resolution:
-      {
-        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
-      }
-    dependencies:
-      safe-buffer: 5.1.2
-    dev: false
-
-  /string_decoder@1.3.0:
-    resolution:
-      {
-        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
-      }
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
   /stringify-entities@4.0.4:
     resolution:
       {
@@ -15919,17 +16003,17 @@ packages:
       inline-style-parser: 0.2.7
     dev: false
 
-  /stylehacks@6.1.1(postcss@8.5.6):
+  /stylehacks@6.1.1(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==,
       }
     engines: { node: ^14 || ^16 || >=18.0 }
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.23'
     dependencies:
       browserslist: 4.28.1
-      postcss: 8.5.6
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
     dev: false
 
@@ -15990,21 +16074,21 @@ packages:
       }
     dev: false
 
-  /svgo@3.3.2:
+  /svgo@4.0.2:
     resolution:
       {
-        integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==,
+        integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==,
       }
-    engines: { node: '>=14.0.0' }
+    engines: { node: '>=16' }
     hasBin: true
     dependencies:
-      '@trysound/sax': 0.2.0
-      commander: 7.2.0
+      commander: 11.1.0
       css-select: 5.2.2
-      css-tree: 2.3.1
+      css-tree: 3.2.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
+      sax: 1.6.1
     dev: false
 
   /tapable@2.3.0:
@@ -16032,7 +16116,7 @@ packages:
       '@swc/core': '*'
       esbuild: '*'
       uglify-js: '*'
-      webpack: ^5.1.0
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -16044,36 +16128,9 @@ packages:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.7
       terser: 5.46.0
       webpack: 5.105.3
-    dev: false
-
-  /terser-webpack-plugin@5.3.16(webpack@5.91.0):
-    resolution:
-      {
-        integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==,
-      }
-    engines: { node: '>= 10.13.0' }
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.46.0
-      webpack: 5.91.0
     dev: false
 
   /terser@5.46.0:
@@ -16149,6 +16206,17 @@ packages:
         integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
       }
     engines: { node: '>=18' }
+    dev: false
+
+  /tinyglobby@0.2.17:
+    resolution:
+      {
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
+      }
+    engines: { node: '>=12.0.0' }
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
     dev: false
 
   /tinypool@1.1.1:
@@ -16290,15 +16358,16 @@ packages:
     engines: { node: '>=12.20' }
     dev: false
 
-  /type-is@1.6.18:
+  /type-is@2.1.0:
     resolution:
       {
-        integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==,
+        integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==,
       }
-    engines: { node: '>= 0.6' }
+    engines: { node: '>= 18' }
     dependencies:
-      media-typer: 0.3.0
-      mime-types: 2.1.35
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
     dev: false
 
   /typed-array-buffer@1.0.3:
@@ -16624,7 +16693,7 @@ packages:
     engines: { node: '>= 10.13.0' }
     peerDependencies:
       file-loader: '*'
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       file-loader:
         optional: true
@@ -16658,28 +16727,11 @@ packages:
     engines: { node: '>= 4' }
     dev: false
 
-  /utils-merge@1.0.1:
+  /uuid@14.0.1:
     resolution:
       {
-        integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==,
+        integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==,
       }
-    engines: { node: '>= 0.4.0' }
-    dev: false
-
-  /uuid@11.1.0:
-    resolution:
-      {
-        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
-      }
-    hasBin: true
-    dev: false
-
-  /uuid@8.3.2:
-    resolution:
-      {
-        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
-      }
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
     dev: false
 
@@ -16736,55 +16788,6 @@ packages:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  /vscode-jsonrpc@8.2.0:
-    resolution:
-      {
-        integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==,
-      }
-    engines: { node: '>=14.0.0' }
-    dev: false
-
-  /vscode-languageserver-protocol@3.17.5:
-    resolution:
-      {
-        integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==,
-      }
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-    dev: false
-
-  /vscode-languageserver-textdocument@1.0.12:
-    resolution:
-      {
-        integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==,
-      }
-    dev: false
-
-  /vscode-languageserver-types@3.17.5:
-    resolution:
-      {
-        integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==,
-      }
-    dev: false
-
-  /vscode-languageserver@9.0.1:
-    resolution:
-      {
-        integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==,
-      }
-    hasBin: true
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-    dev: false
-
-  /vscode-uri@3.1.0:
-    resolution:
-      {
-        integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==,
-      }
-    dev: false
-
   /watchpack@2.5.1:
     resolution:
       {
@@ -16804,15 +16807,6 @@ packages:
     engines: { node: '>=10.13.0' }
     dependencies:
       graceful-fs: 4.2.11
-
-  /wbuf@1.7.3:
-    resolution:
-      {
-        integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==,
-      }
-    dependencies:
-      minimalistic-assert: 1.0.1
-    dev: false
 
   /web-namespaces@2.0.1:
     resolution:
@@ -16847,28 +16841,26 @@ packages:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.10
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.3):
+  /webpack-dev-middleware@8.1.1(tslib@2.8.1)(webpack@5.105.3):
     resolution:
       {
-        integrity: sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==,
+        integrity: sha512-JrxAE/HwNmEnTkzkUGHFItHpGalzuEIUDifXhjAkIEHZzHK/ZJFVoTQF5ubZQlgeRireqLdr2lZttrrmOH61IA==,
       }
-    engines: { node: '>= 18.12.0' }
+    engines: { node: '>= 20.9.0' }
     peerDependencies:
-      webpack: ^5.0.0
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       webpack:
         optional: true
     dependencies:
-      colorette: 2.0.20
       memfs: 4.56.10(tslib@2.8.1)
       mime-types: 3.0.2
-      on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.3.3
       webpack: 5.105.3
@@ -16876,15 +16868,15 @@ packages:
       - tslib
     dev: false
 
-  /webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.3):
+  /webpack-dev-server@6.0.0(tslib@2.8.1)(webpack@5.105.3):
     resolution:
       {
-        integrity: sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==,
+        integrity: sha512-q9SD4ItOGhZLeU6EGT10caDZdHjF50Pz1DtkRZZOPsfluMXOkacWKKOtSBSLVkPqKiF67eFUC0rI88U/tSFPEw==,
       }
-    engines: { node: '>= 18.12.0' }
+    engines: { node: '>= 22.15.0' }
     hasBin: true
     peerDependencies:
-      webpack: ^5.0.0
+      webpack: '>=5.104.1'
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack:
@@ -16894,36 +16886,32 @@ packages:
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.8
+      '@types/express': 5.0.6
+      '@types/express-serve-static-core': 5.1.3
       '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
+      '@types/serve-static': 2.2.0
       '@types/ws': 8.18.1
       ansi-html-community: 0.0.8
       bonjour-service: 1.3.0
-      chokidar: 3.6.0
-      colorette: 2.0.20
+      chokidar: 5.0.0
       compression: 1.8.1
       connect-history-api-fallback: 2.0.0
-      express: 4.22.1
+      express: 5.2.1
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      http-proxy-middleware: 4.2.0
       ipaddr.js: 2.3.0
-      launch-editor: 2.13.1
-      open: 10.2.0
-      p-retry: 6.2.1
+      launch-editor: 2.14.1
+      open: 11.0.0
+      p-retry: 8.0.0
       schema-utils: 4.3.3
       selfsigned: 5.5.0
       serve-index: 1.9.2
-      sockjs: 0.3.24
-      spdy: 4.0.2
+      tinyglobby: 0.2.17
       webpack: 5.105.3
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.3)
-      ws: 8.19.0
+      webpack-dev-middleware: 8.1.1(tslib@2.8.1)(webpack@5.105.3)
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - supports-color
       - tslib
       - utf-8-validate
@@ -17012,7 +17000,7 @@ packages:
       - uglify-js
     dev: false
 
-  /webpack@5.109.2(postcss@8.5.6):
+  /webpack@5.109.2(postcss@8.5.26):
     resolution:
       {
         integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==,
@@ -17039,7 +17027,7 @@ packages:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(postcss@8.5.6)(webpack@5.109.2)
+      minimizer-webpack-plugin: 5.6.1(postcss@8.5.26)(webpack@5.109.2)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -17059,49 +17047,6 @@ packages:
       - postcss
       - uglify-js
 
-  /webpack@5.91.0:
-    resolution:
-      {
-        integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==,
-      }
-    engines: { node: '>=10.13.0' }
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-assertions: 1.9.0(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 1.7.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(webpack@5.91.0)
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: false
-
   /webpackbar@7.0.0(webpack@5.105.3):
     resolution:
       {
@@ -17110,7 +17055,7 @@ packages:
     engines: { node: '>=14.21.3' }
     peerDependencies:
       '@rspack/core': '*'
-      webpack: 3 || 4 || 5
+      webpack: '>=5.104.1'
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -17122,26 +17067,6 @@ packages:
       pretty-time: 1.1.0
       std-env: 3.10.0
       webpack: 5.105.3
-    dev: false
-
-  /websocket-driver@0.7.4:
-    resolution:
-      {
-        integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==,
-      }
-    engines: { node: '>=0.8.0' }
-    dependencies:
-      http-parser-js: 0.5.10
-      safe-buffer: 5.2.1
-      websocket-extensions: 0.1.4
-    dev: false
-
-  /websocket-extensions@0.1.4:
-    resolution:
-      {
-        integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==,
-      }
-    engines: { node: '>=0.8.0' }
     dev: false
 
   /whatwg-url@5.0.0:
@@ -17288,6 +17213,13 @@ packages:
       strip-ansi: 7.2.0
     dev: false
 
+  /wrappy@1.0.2:
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
+    dev: false
+
   /write-file-atomic@3.0.3:
     resolution:
       {
@@ -17300,26 +17232,10 @@ packages:
       typedarray-to-buffer: 3.1.5
     dev: false
 
-  /ws@7.5.10:
+  /ws@8.21.3:
     resolution:
       {
-        integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==,
-      }
-    engines: { node: '>=8.3.0' }
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
-
-  /ws@8.19.0:
-    resolution:
-      {
-        integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==,
+        integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==,
       }
     engines: { node: '>=10.0.0' }
     peerDependencies:
@@ -17332,14 +17248,15 @@ packages:
         optional: true
     dev: false
 
-  /wsl-utils@0.1.0:
+  /wsl-utils@0.3.1:
     resolution:
       {
-        integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==,
+        integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==,
       }
-    engines: { node: '>=18' }
+    engines: { node: '>=20' }
     dependencies:
       is-wsl: 3.1.1
+      powershell-utils: 0.1.0
     dev: false
 
   /xdg-basedir@5.1.0:
@@ -17367,12 +17284,13 @@ packages:
       }
     dev: false
 
-  /yaml@1.10.2:
+  /yaml@2.9.0:
     resolution:
       {
-        integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==,
+        integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
       }
-    engines: { node: '>= 6' }
+    engines: { node: '>= 14.6' }
+    hasBin: true
     dev: true
 
   /yocto-queue@1.2.2:


### PR DESCRIPTION
Reduced pnpm audit results from 78 vulnerabilities to 2, which are currently unfixable because the the maintainers of `image-size` haven't shipped a patched release.
